### PR TITLE
Fix PM table layout

### DIFF
--- a/public/pm.html
+++ b/public/pm.html
@@ -127,11 +127,13 @@
             width: 100%;
             border-collapse: collapse;
             border: 1px solid #ddd;
+            table-layout: fixed; /* Ensure columns expand to fill width */
         }
         th, td {
             padding: 12px;
             text-align: left;
             border-bottom: 1px solid #ddd;
+            word-wrap: break-word; /* Prevent overflow when width is fixed */
         }
         th {
             background-color: #f2f2f2;


### PR DESCRIPTION
## Summary
- ensure the PM table expands to fill the container by using `table-layout: fixed`
- prevent cell overflow with `word-wrap: break-word`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b6cc9f0608326abcb050fd407bc37