### PR TITLE
Adjust header KPI spacing

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -151,6 +151,13 @@
             background: #fff;
             font-weight: bold;
         }
+        .top-border .header-kpi:first-of-type,
+        .top-border .header-mt {
+            margin-left: 160px;
+        }
+        .top-border .header-kpi:last-of-type {
+            margin-right: 160px;
+        }
         #config-form { display:none; margin-top:20px; }
         label { display:block; margin-top:10px; }
     </style>

--- a/public/index.html
+++ b/public/index.html
@@ -169,6 +169,13 @@
             background: #fff;
             font-weight: bold;
         }
+        .top-border .header-kpi:first-of-type,
+        .top-border .header-mt {
+            margin-left: 160px;
+        }
+        .top-border .header-kpi:last-of-type {
+            margin-right: 160px;
+        }
     </style>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" charset="utf-8">
 </head>

--- a/public/pm.html
+++ b/public/pm.html
@@ -171,6 +171,13 @@
             background: #fff;
             font-weight: bold;
         }
+        .top-border .header-kpi:first-of-type,
+        .top-border .header-mt {
+            margin-left: 160px;
+        }
+        .top-border .header-kpi:last-of-type {
+            margin-right: 160px;
+        }
     </style>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" charset="utf-8">
 </head>


### PR DESCRIPTION
## Summary
- tweak header CSS for index, PM, and admin pages
  - shift first KPI group right of pri-logo
  - shift last KPI group left of innovation logo

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b95bfbb208326bf90cae43e6781ca