### PR TITLE
Fix production status asset mapping

### DIFF
--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -507,8 +507,8 @@ Promise.all([
   tbody.innerHTML = '';
 
   mappings.productionAssets.forEach(item => {
-    // look up by the Limble field name (here 'id')
-    const a = assets.find(x => x.id === item.id);
+    // assets from the API use `assetID` for the identifier
+    const a = assets.find(x => x.assetID === item.id);
     if (!a) {
       console.warn(`Asset ${item.id} (“${item.name}”) not in API response.`);
       return;

--- a/server.js
+++ b/server.js
@@ -20,7 +20,10 @@ const rawMappings = fs.readFileSync(
   'utf8'
 );
 const mappings = JSON.parse(rawMappings);
-const assetIDs = Object.keys(mappings).join(',');  // "2399,2400,..."
+// Build a comma separated list of asset IDs used for production status/KPIs
+const assetIDs = Array.isArray(mappings.productionAssets)
+  ? mappings.productionAssets.map(a => a.id).join(',')
+  : '';
 
 // ─── network info ─────────────────────────────────────────────────────────
 const nets = os.networkInterfaces();


### PR DESCRIPTION
## Summary
- use productionAssets to build the asset list used by the API
- match `assetID` when looking up asset data on the production status page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bd657eec88326aaac3eca8fa7655e