### PR TITLE
Update KPI calculation to previous month

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,5 +1,20 @@
 import request from 'supertest';
+import { jest } from '@jest/globals';
 import app from '../server.js';
+
+const dummyOverall = {
+  uptimePct: 99,
+  downtimeHrs: 1,
+  mttrHrs: 2,
+  mtbfHrs: 3,
+  plannedCount: 4,
+  unplannedCount: 5
+};
+
+const dummyByAsset = {
+  assets: { 1: { name: 'Asset1' } },
+  totals: { foo: 'bar' }
+};
 
 describe('API routes', () => {
   test('GET / responds with html', async () => {
@@ -24,5 +39,30 @@ describe('API routes', () => {
     const res = await request(app).get('/api/config');
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toMatch(/json/);
+  });
+
+  test('GET /api/kpis returns cached values', async () => {
+    const spy = jest.spyOn(app, 'fetchAndCache').mockImplementation(async (key) => {
+      if (key === 'kpis_overall') return dummyOverall;
+      if (key === 'kpis_byAsset') return dummyByAsset;
+    });
+
+    const res = await request(app).get('/api/kpis');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ overall: dummyOverall, byAsset: dummyByAsset });
+
+    spy.mockRestore();
+  });
+
+  test('GET /api/kpis-by-asset returns cached values', async () => {
+    const spy = jest.spyOn(app, 'fetchAndCache').mockImplementation(async (key) => {
+      if (key === 'kpis_byAsset') return dummyByAsset;
+    });
+
+    const res = await request(app).get('/api/kpis-by-asset');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(dummyByAsset);
+
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- switch MTTR/MTBF calculations from rolling 30 days to previous month
- expose `fetchAndCache` on the app and call it through the app for easier spying
- add jest tests for `/api/kpis` and `/api/kpis-by-asset`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d0f7114508326b11a7c486a65c2ae