### PR TITLE
Add rotation pause control

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -60,6 +60,12 @@
             background-color: rgba(146, 208, 80, 1);
             z-index: 1;
         }
+        #toggle-rotation {
+            display: block;
+            width: 110px;
+            margin: 10px auto;
+            font-size: 12px;
+        }
         .weather-container {
             margin-top: 140px;
             display: flex;
@@ -185,6 +191,7 @@
         <img src="img/innovation-logo.png" alt="Innovation Logo">
     </div>
     <div class="left-border">
+        <button id="toggle-rotation">Pause Rotation</button>
         <div id="weather-container" class="weather-container"></div>
     </div>
     <div class="container">
@@ -214,6 +221,35 @@
     <button id="refresh-cache">Refresh Cache</button>
     </div>
     <script>
+        const rotateBtn = document.getElementById('toggle-rotation');
+        function updateRotateButton() {
+            const paused = localStorage.getItem('rotationPaused') === 'true';
+            rotateBtn.textContent = paused ? 'Resume Rotation' : 'Pause Rotation';
+        }
+        rotateBtn.addEventListener('click', () => {
+            const paused = localStorage.getItem('rotationPaused') === 'true';
+            localStorage.setItem('rotationPaused', paused ? 'false' : 'true');
+            updateRotateButton();
+        });
+        updateRotateButton();
+        let config = {};
+        fetch('/config.json')
+            .then(r => r.json())
+            .then(cfg => { config = cfg; rotatePages(); })
+            .catch(() => { config = {}; });
+
+        function rotatePages() {
+            if (!config.pages) return;
+            const page = window.location.pathname.split('/').pop() || 'admin.html';
+            const pages = config.pages;
+            const interval = config.interval || 15000;
+            const next = pages[(pages.indexOf(page) + 1) % pages.length];
+            setTimeout(() => {
+                if (localStorage.getItem('rotationPaused') === 'true') return;
+                if (next && next !== page) window.location.href = '/' + next;
+            }, interval);
+        }
+
         let adminPass = '';
         document.getElementById('login-btn').onclick = async () => {
             adminPass = document.getElementById('admin-pass').value;

--- a/public/index.html
+++ b/public/index.html
@@ -59,6 +59,12 @@
             background-color: rgba(146, 208, 80, 1);
             z-index: 1; /* Adjust the z-index to be below the top border */
         }
+        #toggle-rotation {
+            display: block;
+            width: 110px;
+            margin: 10px auto;
+            font-size: 12px;
+        }
         .weather-container {
             margin-top: 140px;
             display: flex;
@@ -202,6 +208,7 @@
       <img src="img/innovation-logo.png" alt="Innovation Logo" />
     </div>
     <div class="left-border">
+        <button id="toggle-rotation">Pause Rotation</button>
         <div id="weather-container" class="weather-container"></div>
     </div>
     <div class="container">
@@ -255,6 +262,7 @@
     //const workOrderDataContainer = document.getElementById('work-order-data');
         const refreshButton = document.getElementById('refresh-button');
     const workOrderDataContainer = document.getElementById('work-order-data');
+    const rotateBtn = document.getElementById('toggle-rotation');
     let mappings = {};
     let config = {};
 
@@ -262,6 +270,17 @@
         .then(res => res.json())
         .then(cfg => { config = cfg; rotatePages(); })
         .catch(() => { config = {}; });
+
+    function updateRotateButton() {
+        const paused = localStorage.getItem('rotationPaused') === 'true';
+        rotateBtn.textContent = paused ? 'Resume Rotation' : 'Pause Rotation';
+    }
+    rotateBtn.addEventListener('click', () => {
+        const paused = localStorage.getItem('rotationPaused') === 'true';
+        localStorage.setItem('rotationPaused', paused ? 'false' : 'true');
+        updateRotateButton();
+    });
+    updateRotateButton();
 
     fetch('/mappings.json')
         .then(res => res.json())
@@ -364,6 +383,7 @@
             const interval = config.interval || 15000;
             const next = pages[(pages.indexOf(page) + 1) % pages.length];
             setTimeout(() => {
+                if (localStorage.getItem('rotationPaused') === 'true') return;
                 if (next && next !== page) window.location.href = '/' + next;
             }, interval);
         }

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -12,6 +12,7 @@
     #clock { flex:1; text-align:center; font-size:48px; font-weight:bold; }
     .clock-date { display:block; font-size:20px; }
     .left-border { position:fixed; top:0; left:0; width:128px; height:100%; background:rgba(146,208,80,1); z-index:1; }
+    #toggle-rotation { display:block; width:110px; margin:10px auto; font-size:12px; }
     .container { max-width:1200px; margin:120px 20px 20px 160px; padding:20px; background:#fff; box-shadow:0 2px 4px rgba(0,0,0,0.1); border-radius:8px; position:relative; z-index:1; }
     h1 { text-align:center; margin-bottom:20px; color:rgba(37,64,143,1); }
     table { width:100%; border-collapse:collapse; border:1px solid #ddd; }
@@ -47,7 +48,9 @@
   <div class="right-top-image">
     <img src="img/innovation-logo.png" alt="Innovation Logo" />
   </div>
-  <div class="left-border"></div>
+  <div class="left-border">
+    <button id="toggle-rotation">Pause Rotation</button>
+  </div>
   <div class="container">
     <h1>Asset KPIs (Last Month)</h1>
     <div class="tabs">
@@ -76,6 +79,37 @@
     </table>
   </div>
   <script>
+    const rotateBtn = document.getElementById('toggle-rotation');
+    let config = {};
+
+    fetch('/config.json')
+      .then(r => r.json())
+      .then(cfg => { config = cfg; rotatePages(); })
+      .catch(() => { config = {}; });
+
+    function updateRotateButton() {
+      const paused = localStorage.getItem('rotationPaused') === 'true';
+      rotateBtn.textContent = paused ? 'Resume Rotation' : 'Pause Rotation';
+    }
+    rotateBtn.addEventListener('click', () => {
+      const paused = localStorage.getItem('rotationPaused') === 'true';
+      localStorage.setItem('rotationPaused', paused ? 'false' : 'true');
+      updateRotateButton();
+    });
+    updateRotateButton();
+
+    function rotatePages() {
+      if (!config.pages) return;
+      const page = window.location.pathname.split('/').pop() || 'kpi-by-asset.html';
+      const pages = config.pages;
+      const interval = config.interval || 15000;
+      const next = pages[(pages.indexOf(page) + 1) % pages.length];
+      setTimeout(() => {
+        if (localStorage.getItem('rotationPaused') === 'true') return;
+        if (next && next !== page) window.location.href = '/' + next;
+      }, interval);
+    }
+
     function updateClock() {
       const now = new Date();
       const dateFmt = new Intl.DateTimeFormat('en-US', { timeZone:'America/Indiana/Indianapolis', weekday:'short', month:'short', day:'numeric', year:'numeric' });

--- a/public/pm.html
+++ b/public/pm.html
@@ -59,6 +59,12 @@
             background-color: rgba(146, 208, 80, 1);
             z-index: 1; /* Adjust the z-index to be below the top border */
         }
+        #toggle-rotation {
+            display: block;
+            width: 110px;
+            margin: 10px auto;
+            font-size: 12px;
+        }
         .weather-container {
             margin-top: 140px;
             display: flex;
@@ -204,6 +210,7 @@
         <img src="img/innovation-logo.png" alt="Innovation Logo">
     </div>
     <div class="left-border">
+        <button id="toggle-rotation">Pause Rotation</button>
         <div id="weather-container" class="weather-container"></div>
     </div>
     <div class="container">
@@ -257,6 +264,7 @@
     //const workOrderDataContainer = document.getElementById('work-order-data');
         const refreshButton = document.getElementById('refresh-button');
     const workOrderDataContainer = document.getElementById('work-order-data');
+    const rotateBtn = document.getElementById('toggle-rotation');
     let mappings = {};
     let config = {};
 
@@ -264,6 +272,17 @@
         .then(res => res.json())
         .then(cfg => { config = cfg; rotatePages(); })
         .catch(() => { config = {}; });
+
+    function updateRotateButton() {
+        const paused = localStorage.getItem('rotationPaused') === 'true';
+        rotateBtn.textContent = paused ? 'Resume Rotation' : 'Pause Rotation';
+    }
+    rotateBtn.addEventListener('click', () => {
+        const paused = localStorage.getItem('rotationPaused') === 'true';
+        localStorage.setItem('rotationPaused', paused ? 'false' : 'true');
+        updateRotateButton();
+    });
+    updateRotateButton();
 
     fetch('/mappings.json')
         .then(res => res.json())
@@ -385,6 +404,7 @@
             const interval = config.interval || 15000;
             const next = pages[(pages.indexOf(page) + 1) % pages.length];
             setTimeout(() => {
+                if (localStorage.getItem('rotationPaused') === 'true') return;
                 if (next && next !== page) window.location.href = '/' + next;
             }, interval);
         }

--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -59,6 +59,12 @@
             background-color: rgba(146, 208, 80, 1);
             z-index: 1; /* Adjust the z-index to be below the top border */
         }
+        #toggle-rotation {
+            display: block;
+            width: 110px;
+            margin: 10px auto;
+            font-size: 12px;
+        }
         .weather-container {
             margin-top: 140px;
             display: flex;
@@ -205,6 +211,7 @@
       <img src="img/innovation-logo.png" alt="Innovation Logo" />
     </div>
     <div class="left-border">
+        <button id="toggle-rotation">Pause Rotation</button>
         <div id="weather-container" class="weather-container"></div>
     </div>
     <div class="container">
@@ -267,6 +274,7 @@
         const refreshButton = document.getElementById('refresh-button');
         const refreshStatusButton = document.getElementById('refresh-status');
     const workOrderDataContainer = document.getElementById('work-order-data');
+    const rotateBtn = document.getElementById('toggle-rotation');
     let mappings = {};
     let config = {};
 
@@ -274,6 +282,17 @@
         .then(res => res.json())
         .then(cfg => { config = cfg; rotatePages(); })
         .catch(() => { config = {}; });
+
+    function updateRotateButton() {
+        const paused = localStorage.getItem('rotationPaused') === 'true';
+        rotateBtn.textContent = paused ? 'Resume Rotation' : 'Pause Rotation';
+    }
+    rotateBtn.addEventListener('click', () => {
+        const paused = localStorage.getItem('rotationPaused') === 'true';
+        localStorage.setItem('rotationPaused', paused ? 'false' : 'true');
+        updateRotateButton();
+    });
+    updateRotateButton();
 
     fetch('/mappings.json')
         .then(res => res.json())
@@ -376,6 +395,7 @@
             const interval = config.interval || 15000;
             const next = pages[(pages.indexOf(page) + 1) % pages.length];
             setTimeout(() => {
+                if (localStorage.getItem('rotationPaused') === 'true') return;
                 if (next && next !== page) window.location.href = '/' + next;
             }, interval);
         }

--- a/server.js
+++ b/server.js
@@ -223,7 +223,6 @@ async function loadByAssetKpis() {
     const downtimeHours    = downtimeSec / 3600;
     const operationalHours = (totalSec - downtimeSec) / 3600;
 
-    const entries = Array.isArray(labor.entries) ? labor.entries : [];
     const downtimeMinutes = entries.filter(e => e.taskType === 'wo' && e.downtime).reduce((s, e) => s + e.duration, 0);
 
     const mttr = unplannedCount ? (downtimeMinutes / 60) / unplannedCount : 0;


### PR DESCRIPTION
## Summary
- add a pause/resume rotation button to each page's sidebar
- persist pause state in localStorage and check it during page rotation
- fix duplicate variable in `server.js`

## Testing
- `npm test` *(fails: Cannot assign to read only property 'fetchAndCache')*

------
https://chatgpt.com/codex/tasks/task_e_688d2827e5248326904ca6414d472279