### PR TITLE
Fix color mapping for status table

### DIFF
--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -532,7 +532,10 @@ Promise.all([
     const entry = status.find(s => s.assetID === item.id) || {};
     const tr = document.createElement('tr');
     // ★ look up the color for this status (fall back to white)
-    const bg = (mappings.statusColorMapping || {})[entry.status] || '#fff';
+    const colorMap = mappings.statusColorMapping || {};
+    const textMap  = mappings.statusTextMapping || {};
+    const statusId = Object.keys(textMap).find(k => textMap[k] === entry.status);
+    const bg = colorMap[statusId] || colorMap[entry.status] || '#fff';
     // ★ apply it to the row
     tr.style.backgroundColor = bg;
     tr.innerHTML = `


### PR DESCRIPTION
## Summary
- map status text to color IDs so production status table gets the right row colors

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot assign to read only property 'fetchAndCache')*

------
https://chatgpt.com/codex/tasks/task_e_688d4444968c832698ad330269998296