### PR TITLE
Fix kpi-by-asset header logo and improve table style

### DIFF
--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -15,9 +15,12 @@
     #toggle-rotation { display:block; width:110px; margin:10px auto; font-size:12px; }
     .container { max-width:1200px; margin:120px 20px 20px 160px; padding:20px; background:#fff; box-shadow:0 2px 4px rgba(0,0,0,0.1); border-radius:8px; position:relative; z-index:1; }
     h1 { text-align:center; margin-bottom:20px; color:rgba(37,64,143,1); }
-    table { width:100%; border-collapse:collapse; border:1px solid #ddd; }
-    th, td { padding:12px; text-align:left; border-bottom:1px solid #ddd; }
-    th { background:#f2f2f2; }
+    table { width:100%; border-collapse:collapse; border:1px solid #ddd; font-size:2rem; }
+    th, td { padding:12px; text-align:center; border-bottom:1px solid #ddd; }
+    th { background:#25408F; color:#fff; }
+    tbody tr:nth-child(even) { background:#f9f9f9; }
+    tbody tr:nth-child(odd) { background:#fff; }
+    .logo { position:absolute; top:20px; left:20px; max-width:200px; max-height:200px; width:auto; height:auto; }
     .tabs { margin:10px 0; }
     .tabs a { text-decoration:none; color:#000; padding:8px 12px; border:1px solid #ccc; border-bottom:none; background:#eee; border-radius:4px 4px 0 0; margin-right:4px; }
     .tabs a.active { background:#fff; font-weight:bold; }


### PR DESCRIPTION
## Summary
- match header logo sizing with other pages
- give KPI table a professional style

## Testing
- `npm test` *(fails: Cannot assign to read only property 'fetchAndCache')*

------
https://chatgpt.com/codex/tasks/task_e_688d4c8b3af483269fa29e65d086ce80