### PR TITLE
Adjust refresh interval and countdown timers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ PORT=3000
 LOCAL_IP=0.0.0.0
 ADMIN_PASSWORD=changeMe
 # Minutes before cached KPI and status data expires
-CACHE_TTL_MINUTES=60
+CACHE_TTL_MINUTES=15
 # How often expired cache entries are cleared
 CACHE_CHECK_PERIOD_SECONDS=1800
 # Endpoint used by the frontend to force a cache refresh

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ table.
 3. (Optional) Adjust `PORT` and `LOCAL_IP` in `.env` to change where the server listens. Set `LOCAL_IP` to `192.168.48.255` to host on that address. Set `ADMIN_PASSWORD` for accessing the admin page.
 4. (Optional) Configure cache settings in `.env`:
    ```bash
-   CACHE_TTL_MINUTES=60
+   CACHE_TTL_MINUTES=15
  CACHE_CHECK_PERIOD_SECONDS=1800
  STATUS_REFRESH_ENDPOINT=/api/cache/refresh
  API_BASE_URL=https://api.limblecmms.com:443
@@ -61,7 +61,7 @@ table.
 
 ### Cache settings
 The cache is controlled via environment variables:
-- `CACHE_TTL_MINUTES` – minutes before KPI and status data is refreshed (default `60`)
+- `CACHE_TTL_MINUTES` – minutes before KPI and status data is refreshed (default `15`)
 - `CACHE_CHECK_PERIOD_SECONDS` – how often the cache trims expired items (default `1800`)
 - `STATUS_REFRESH_ENDPOINT` – route for manually forcing a refresh (default `/api/cache/refresh`)
 - `API_BASE_URL` – base URL for Limble API requests (default `https://api.limblecmms.com:443`)

--- a/public/admin.html
+++ b/public/admin.html
@@ -102,7 +102,7 @@
             font-weight: bold;
         }
         .container {
-            max-width: 1200px;
+            max-width: 1440px;
             margin: 120px 20px 20px 160px;
             padding: 20px;
             background-color: #fff;

--- a/public/index.html
+++ b/public/index.html
@@ -101,7 +101,7 @@
             font-weight: bold;
         }
         .container {
-            max-width: 1200px;
+            max-width: 1440px;
             margin: 120px 20px 20px 160px; /* Adjust margins to match border width and height */
             padding: 20px;
             background-color: #fff;
@@ -140,9 +140,9 @@
             text-align: left;
             border-bottom: 1px solid #ddd;
         }
-        th {
-            background-color: #f2f2f2;
-        }
+        th { background:#25408F; color:#fff; }
+        tbody tr:nth-child(even) { background:#e0e0e0; }
+        tbody tr:nth-child(odd) { background:#fff; }
         .logo {
             position: absolute;
             top: 20px;
@@ -502,7 +502,7 @@
     } catch (err) { console.error('Failed to load KPIs', err); }
   }
   updateKPIs();
-  setInterval(updateKPIs, 3600000);
+  setInterval(updateKPIs, 900000);
 </script>
 </body>
 </html>

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -13,6 +13,7 @@
     .clock-date { display:block; font-size:20px; }
     .left-border { position:fixed; top:0; left:0; width:128px; height:100%; background:rgba(146,208,80,1); z-index:1; }
     #toggle-rotation { display:block; width:110px; margin:10px auto; font-size:12px; }
+    #refresh-timer { margin-left:10px; font-weight:bold; }
     .container { max-width:1200px; margin:120px 20px 20px 160px; padding:20px; background:#fff; box-shadow:0 2px 4px rgba(0,0,0,0.1); border-radius:8px; position:relative; z-index:1; }
     h1 { text-align:center; margin-bottom:20px; color:rgba(37,64,143,1); }
     table { width:115%; border-collapse:collapse; border:1px solid #ddd; font-size:1.8rem; }
@@ -63,6 +64,10 @@
       <a href="/kpi-by-asset.html" class="active">KPIs by Asset</a>
       <a href="/admin">Admin</a>
     </div>
+    <div>
+      <button id="refresh-button">Refresh</button>
+      <span id="refresh-timer"></span>
+    </div>
     <table id="kpi-table">
       <thead>
         <tr>
@@ -83,6 +88,10 @@
   </div>
   <script>
     const rotateBtn = document.getElementById('toggle-rotation');
+    const refreshTimerEl = document.getElementById('refresh-timer');
+    const refreshButton  = document.getElementById('refresh-button');
+    const refreshInterval = 900000; // 15 minutes
+    let refreshCountdown = refreshInterval / 1000;
     let config = {};
 
     fetch('/config.json')
@@ -100,6 +109,15 @@
       updateRotateButton();
     });
     updateRotateButton();
+
+    function updateRefreshTimer() {
+      const m = Math.floor(refreshCountdown / 60);
+      const s = String(refreshCountdown % 60).padStart(2, '0');
+      refreshTimerEl.textContent = `Next refresh in ${m}:${s}`;
+      refreshCountdown = refreshCountdown > 0 ? refreshCountdown - 1 : refreshInterval / 1000;
+    }
+    setInterval(updateRefreshTimer, 1000);
+    updateRefreshTimer();
 
     function rotatePages() {
       if (!config.pages) return;
@@ -134,7 +152,7 @@
       } catch (err) { console.error('Failed to load KPIs', err); }
     }
     updateKPIs();
-    setInterval(updateKPIs, 3600000);
+    setInterval(updateKPIs, 900000);
 
     async function loadAssetKPIs() {
       try {
@@ -155,7 +173,11 @@
       }
     }
     loadAssetKPIs();
-    setInterval(loadAssetKPIs, 3600000);
+    setInterval(() => { loadAssetKPIs(); refreshCountdown = refreshInterval / 1000; }, refreshInterval);
+    refreshButton.addEventListener('click', () => {
+      loadAssetKPIs();
+      refreshCountdown = refreshInterval / 1000;
+    });
   </script>
 </body>
 </html>

--- a/public/pm.html
+++ b/public/pm.html
@@ -101,7 +101,7 @@
             font-weight: bold;
         }
         .container {
-            max-width: 1200px;
+            max-width: 1440px;
             margin: 120px 20px 20px 160px; /* Adjust margins to match border width and height */
             padding: 20px;
             background-color: #fff;
@@ -142,9 +142,9 @@
             border-bottom: 1px solid #ddd;
             word-wrap: break-word; /* Prevent overflow when width is fixed */
         }
-        th {
-            background-color: #f2f2f2;
-        }
+        th { background:#25408F; color:#fff; }
+        tbody tr:nth-child(even) { background:#e0e0e0; }
+        tbody tr:nth-child(odd) { background:#fff; }
         .logo {
             position: absolute;
             top: 20px;
@@ -502,7 +502,7 @@
         } catch (err) { console.error('Failed to load KPIs', err); }
     }
     updateKPIs();
-    setInterval(updateKPIs, 3600000);
+    setInterval(updateKPIs, 900000);
 </script>
 </body>
 </html>

--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -101,7 +101,7 @@
             font-weight: bold;
         }
         .container {
-            max-width: 1200px;
+            max-width: 1440px;
             margin: 120px 20px 20px 160px; /* Adjust margins to match border width and height */
             padding: 20px;
             background-color: #fff;
@@ -129,6 +129,10 @@
             border-radius: 4px;
             cursor: pointer;
             font-size: 14px;
+        }
+        #refresh-timer {
+            margin-left: 10px;
+            font-weight: bold;
         }
         table {
             width: 115%;
@@ -190,6 +194,10 @@
         #status-table tr {
             height: 72px;
         }
+        #status-table thead th {
+            background:#25408F;
+            color:#fff;
+        }
     </style>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" charset="utf-8">
 </head>
@@ -242,6 +250,7 @@
             <!--<input type="text" id="input-value" placeholder="Enter a value">-->
             <!--<button id="fetch-button">Fetch Work Orders</button>-->
             <button id="refresh-button">Refresh</button>
+            <span id="refresh-timer"></span>
             <button id="refresh-status">Admin → Refresh status</button>
         </div>
 
@@ -280,6 +289,9 @@
         const refreshStatusButton = document.getElementById('refresh-status');
     const workOrderDataContainer = document.getElementById('work-order-data');
     const rotateBtn = document.getElementById('toggle-rotation');
+    const refreshTimerEl = document.getElementById('refresh-timer');
+    const refreshInterval = 900000; // 15 minutes
+    let refreshCountdown = refreshInterval / 1000;
     let mappings = {};
     let config = {};
 
@@ -292,6 +304,14 @@
         const paused = localStorage.getItem('rotationPaused') === 'true';
         rotateBtn.textContent = paused ? 'Resume Rotation' : 'Pause Rotation';
     }
+    function updateRefreshTimer() {
+        const m = Math.floor(refreshCountdown / 60);
+        const s = String(refreshCountdown % 60).padStart(2, '0');
+        refreshTimerEl.textContent = `Next refresh in ${m}:${s}`;
+        refreshCountdown = refreshCountdown > 0 ? refreshCountdown - 1 : refreshInterval / 1000;
+    }
+    setInterval(updateRefreshTimer, 1000);
+    updateRefreshTimer();
     rotateBtn.addEventListener('click', () => {
         const paused = localStorage.getItem('rotationPaused') === 'true';
         localStorage.setItem('rotationPaused', paused ? 'false' : 'true');
@@ -477,9 +497,13 @@
         });
 	}
         refreshButton.addEventListener('click', () => {
-        // Fetch and load the data without reloading the page
         fetchData();
+        refreshCountdown = refreshInterval / 1000;
     });
+    setInterval(() => {
+        fetchData();
+        refreshCountdown = refreshInterval / 1000;
+    }, refreshInterval);
     refreshStatusButton.addEventListener('click', () => {
         fetch(process.env.STATUS_REFRESH_ENDPOINT || '/api/cache/refresh', { method: 'POST' });
     });

--- a/server.js
+++ b/server.js
@@ -13,7 +13,8 @@ dotenv.config();
 
 const API_V2 = `${process.env.API_BASE_URL}/v2`;
 
-const cacheTtlSeconds = Number(process.env.CACHE_TTL_MINUTES ?? 60) * 60;
+// Default to a 15 minute cache refresh if env var not set
+const cacheTtlSeconds = Number(process.env.CACHE_TTL_MINUTES ?? 15) * 60;
 const checkPeriod = Number(process.env.CACHE_CHECK_PERIOD_SECONDS ?? 1800);
 const cache = new NodeCache({ stdTTL: cacheTtlSeconds, checkperiod: checkPeriod });
 


### PR DESCRIPTION
## Summary
- refresh Limble cache every 15 minutes
- widen table containers
- add countdown timer and refresh button for asset KPI and production status pages
- match table colors across work order pages
- document new refresh rate

## Testing
- `npm test` *(fails: TypeError: Cannot assign to read only property 'fetchAndCache' of object '[object Module]')*

------
https://chatgpt.com/codex/tasks/task_e_688d5d189d508326a66cb8723d57005b