### PR TITLE
Fix hidden status table header and widen dashboard containers

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -102,7 +102,7 @@
             font-weight: bold;
         }
         .container {
-            max-width: 1440px;
+            max-width: 1728px;
             margin: 120px 20px 20px 160px;
             padding: 20px;
             background-color: #fff;

--- a/public/index.html
+++ b/public/index.html
@@ -101,7 +101,7 @@
             font-weight: bold;
         }
         .container {
-            max-width: 1440px;
+            max-width: 1728px;
             margin: 120px 20px 20px 160px; /* Adjust margins to match border width and height */
             padding: 20px;
             background-color: #fff;

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -14,7 +14,7 @@
     .left-border { position:fixed; top:0; left:0; width:128px; height:100%; background:rgba(146,208,80,1); z-index:1; }
     #toggle-rotation { display:block; width:110px; margin:110px auto 10px; font-size:12px; }
     #refresh-timer { margin-left:10px; font-weight:bold; }
-    .container { max-width:1200px; margin:120px 20px 20px 160px; padding:20px; background:#fff; box-shadow:0 2px 4px rgba(0,0,0,0.1); border-radius:8px; position:relative; z-index:1; }
+    .container { max-width:1440px; margin:120px 20px 20px 160px; padding:20px; background:#fff; box-shadow:0 2px 4px rgba(0,0,0,0.1); border-radius:8px; position:relative; z-index:1; }
     h1 { text-align:center; margin-bottom:20px; color:rgba(37,64,143,1); }
     table { width:115%; border-collapse:collapse; border:1px solid #ddd; font-size:1.8rem; }
     th, td { padding:12px; text-align:center; border-bottom:1px solid #ddd; }

--- a/public/pm.html
+++ b/public/pm.html
@@ -101,7 +101,7 @@
             font-weight: bold;
         }
         .container {
-            max-width: 1440px;
+            max-width: 1728px;
             margin: 120px 20px 20px 160px; /* Adjust margins to match border width and height */
             padding: 20px;
             background-color: #fff;

--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -101,7 +101,7 @@
             font-weight: bold;
         }
         .container {
-            max-width: 1440px;
+            max-width: 1728px;
             margin: 120px 20px 20px 160px; /* Adjust margins to match border width and height */
             padding: 20px;
             background-color: #fff;
@@ -403,11 +403,11 @@
             if (!config.columns) return;
             const page = window.location.pathname.split('/').pop() || 'index.html';
             const cols = config.columns[page] || [];
-            document.querySelectorAll('th').forEach(th => {
+            document.querySelectorAll('th[data-col]').forEach(th => {
                 if (!cols.includes(th.dataset.col)) th.style.display = 'none'; else th.style.display = '';
             });
             document.querySelectorAll('#work-order-data tr').forEach(tr => {
-                tr.querySelectorAll('td').forEach(td => {
+                tr.querySelectorAll('td[data-col]').forEach(td => {
                     if (!cols.includes(td.dataset.col)) td.style.display = 'none'; else td.style.display = '';
                 });
             });


### PR DESCRIPTION
## Summary
- keep production status header visible by skipping column-hiding on non-data columns
- widen table container by 20% across dashboard pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e820d12a88326a6cd28133895c15d