### PR TITLE
Indicate rotation state with button color

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -65,6 +65,8 @@
             width: 110px;
             margin: 110px auto 10px;
             font-size: 12px;
+            background-color: blue;
+            color: white;
         }
         .weather-container {
             margin-top: 140px;
@@ -225,6 +227,8 @@
         function updateRotateButton() {
             const paused = localStorage.getItem('rotationPaused') === 'true';
             rotateBtn.textContent = paused ? 'Resume Rotation' : 'Pause Rotation';
+            rotateBtn.style.backgroundColor = paused ? 'red' : 'blue';
+            rotateBtn.style.color = 'white';
         }
         rotateBtn.addEventListener('click', () => {
             const paused = localStorage.getItem('rotationPaused') === 'true';

--- a/public/index.html
+++ b/public/index.html
@@ -64,6 +64,8 @@
             width: 110px;
             margin: 110px auto 10px;
             font-size: 12px;
+            background-color: blue;
+            color: white;
         }
         .weather-container {
             margin-top: 140px;
@@ -274,6 +276,8 @@
     function updateRotateButton() {
         const paused = localStorage.getItem('rotationPaused') === 'true';
         rotateBtn.textContent = paused ? 'Resume Rotation' : 'Pause Rotation';
+        rotateBtn.style.backgroundColor = paused ? 'red' : 'blue';
+        rotateBtn.style.color = 'white';
     }
     rotateBtn.addEventListener('click', () => {
         const paused = localStorage.getItem('rotationPaused') === 'true';

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -12,7 +12,7 @@
     #clock { flex:1; text-align:center; font-size:48px; font-weight:bold; }
     .clock-date { display:block; font-size:20px; }
     .left-border { position:fixed; top:0; left:0; width:128px; height:100%; background:rgba(146,208,80,1); z-index:1; }
-    #toggle-rotation { display:block; width:110px; margin:110px auto 10px; font-size:12px; }
+    #toggle-rotation { display:block; width:110px; margin:110px auto 10px; font-size:12px; background-color: blue; color: white; }
     #refresh-timer { margin-left:10px; font-weight:bold; }
     .container { max-width:1200px; margin:120px 20px 20px 160px; padding:20px; background:#fff; box-shadow:0 2px 4px rgba(0,0,0,0.1); border-radius:8px; position:relative; z-index:1; }
     h1 { text-align:center; margin-bottom:20px; color:rgba(37,64,143,1); }
@@ -102,6 +102,8 @@
     function updateRotateButton() {
       const paused = localStorage.getItem('rotationPaused') === 'true';
       rotateBtn.textContent = paused ? 'Resume Rotation' : 'Pause Rotation';
+      rotateBtn.style.backgroundColor = paused ? 'red' : 'blue';
+      rotateBtn.style.color = 'white';
     }
     rotateBtn.addEventListener('click', () => {
       const paused = localStorage.getItem('rotationPaused') === 'true';

--- a/public/pm.html
+++ b/public/pm.html
@@ -64,6 +64,8 @@
             width: 110px;
             margin: 110px auto 10px;
             font-size: 12px;
+            background-color: blue;
+            color: white;
         }
         .weather-container {
             margin-top: 140px;
@@ -276,6 +278,8 @@
     function updateRotateButton() {
         const paused = localStorage.getItem('rotationPaused') === 'true';
         rotateBtn.textContent = paused ? 'Resume Rotation' : 'Pause Rotation';
+        rotateBtn.style.backgroundColor = paused ? 'red' : 'blue';
+        rotateBtn.style.color = 'white';
     }
     rotateBtn.addEventListener('click', () => {
         const paused = localStorage.getItem('rotationPaused') === 'true';

--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -64,6 +64,8 @@
             width: 110px;
             margin: 110px auto 10px;
             font-size: 12px;
+            background-color: blue;
+            color: white;
         }
         .weather-container {
             margin-top: 140px;
@@ -303,6 +305,8 @@
     function updateRotateButton() {
         const paused = localStorage.getItem('rotationPaused') === 'true';
         rotateBtn.textContent = paused ? 'Resume Rotation' : 'Pause Rotation';
+        rotateBtn.style.backgroundColor = paused ? 'red' : 'blue';
+        rotateBtn.style.color = 'white';
     }
     function updateRefreshTimer() {
         const m = Math.floor(refreshCountdown / 60);


### PR DESCRIPTION
## Summary
- highlight the rotation toggle button in blue and switch to red when rotation is paused
- apply the same color toggling logic across dashboard pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e824d05a883268409c5f181604ab1