### PR TITLE
feat: add burn-in repair mode

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Admin</title>
     <link rel="stylesheet" href="style.css">
+    <script src="burnin.js"></script>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -216,6 +217,19 @@
         <label>Columns for pm.html: <input type="text" id="cols-pm"></label>
         <button type="submit">Save Config</button>
     </form>
+    <div id="burnin-section">
+        <h2>Burn-in Repair Mode</h2>
+        <div id="burnin-status">
+            Scheduled: <span id="burnin-sched">19:00–05:00</span><br>
+            Currently: <span id="burnin-current">Inactive</span><br>
+            Override: <span id="burnin-override">Off</span>
+        </div>
+        <label>Start: <input type="time" id="burnin-start" value="19:00"></label>
+        <label>End: <input type="time" id="burnin-end" value="05:00"></label>
+        <button id="save-burnin">Save Schedule</button>
+        <button id="enter-burnin">Enter Burn-in Now</button>
+        <button id="exit-burnin">Exit Burn-in Now</button>
+    </div>
     <div id="mapping-section" style="display:none;">
         <label>Update mappings.json: <input type="file" id="mapping-file"></label>
         <button id="upload-map">Upload Mapping</button>
@@ -224,6 +238,11 @@
     </div>
     <script>
         const rotateBtn = document.getElementById('toggle-rotation');
+        const burnStart = document.getElementById('burnin-start');
+        const burnEnd = document.getElementById('burnin-end');
+        const burnSchedSpan = document.getElementById('burnin-sched');
+        const burnCurrentSpan = document.getElementById('burnin-current');
+        const burnOverrideSpan = document.getElementById('burnin-override');
         function updateRotateButton() {
             const paused = localStorage.getItem('rotationPaused') === 'true';
             rotateBtn.textContent = paused ? 'Resume Rotation' : 'Pause Rotation';
@@ -237,10 +256,30 @@
         });
         updateRotateButton();
         let config = {};
+        function isBurnActive(sched){
+            const [sh,sm]=sched.start.split(':').map(Number);
+            const [eh,em]=sched.end.split(':').map(Number);
+            const now=new Date();
+            const start=new Date(); start.setHours(sh,sm,0,0);
+            const end=new Date(); end.setHours(eh,em,0,0);
+            const inWindow = start<=end ? (now>=start && now<end) : (now>=start || now<end);
+            const override=localStorage.getItem('burnInOverride');
+            const active=(inWindow && override!=='off') || override==='on';
+            return {active, override};
+        }
+        function updateBurninUI(){
+            const sched=config.burnInSchedule || {start:'19:00',end:'05:00'};
+            burnStart.value=sched.start;
+            burnEnd.value=sched.end;
+            burnSchedSpan.textContent=`${sched.start}–${sched.end}`;
+            const {active, override} = isBurnActive(sched);
+            burnCurrentSpan.textContent = active ? 'Active' : 'Inactive';
+            burnOverrideSpan.textContent = override==='on' ? 'On' : 'Off';
+        }
         fetch('/config.json')
             .then(r => r.json())
-            .then(cfg => { config = cfg; rotatePages(); })
-            .catch(() => { config = {}; });
+            .then(cfg => { config = cfg; updateBurninUI(); rotatePages(); })
+            .catch(() => { config = {}; updateBurninUI(); });
 
         function rotatePages() {
             if (!config.pages) return;
@@ -248,7 +287,8 @@
             const pages = config.pages;
             const interval = config.interval || 15000;
             const next = pages[(pages.indexOf(page) + 1) % pages.length];
-            setTimeout(() => {
+            setTimeout(async () => {
+                if (await checkBurnIn()) return;
                 if (localStorage.getItem('rotationPaused') === 'true') return;
                 if (next && next !== page) window.location.href = '/' + next;
             }, interval);
@@ -259,6 +299,8 @@
             adminPass = document.getElementById('admin-pass').value;
             const res = await fetch('/api/config');
             const cfg = await res.json();
+            config = cfg;
+            updateBurninUI();
             document.getElementById('pages').value = cfg.pages.join(',');
             document.getElementById('interval').value = cfg.interval;
             document.getElementById('cols-index').value = (cfg.columns['index.html'] || []).join(',');
@@ -283,6 +325,25 @@
                 body: JSON.stringify({password: adminPass, config: cfg})
             });
             alert('Config saved');
+        };
+        document.getElementById('save-burnin').onclick = async () => {
+            config.burnInSchedule = { start: burnStart.value, end: burnEnd.value };
+            await fetch('/api/config', {
+                method:'POST',
+                headers:{'Content-Type':'application/json'},
+                body: JSON.stringify({ password: adminPass, config })
+            });
+            updateBurninUI();
+            alert('Schedule saved');
+        };
+        document.getElementById('enter-burnin').onclick = () => {
+            localStorage.setItem('burnInOverride','on');
+            localStorage.setItem('lastPage', window.location.pathname);
+            window.location.href = '/burnin.html';
+        };
+        document.getElementById('exit-burnin').onclick = () => {
+            localStorage.removeItem('burnInOverride');
+            window.location.href = '/';
         };
         document.getElementById('upload-map').onclick = async () => {
             const file = document.getElementById('mapping-file').files[0];

--- a/public/burnin.html
+++ b/public/burnin.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Burn-in Repair Mode</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      background: #fff;
+      overflow: hidden;
+      cursor: pointer;
+      font-family: Arial, sans-serif;
+    }
+    .message {
+      position: absolute;
+      font-size: 48px;
+      color: #000;
+      text-align: center;
+      animation: drift 300s infinite ease-in-out;
+    }
+    @keyframes drift {
+      0%   { transform: translate(0,0); }
+      25%  { transform: translate(80vw,10vh); }
+      50%  { transform: translate(20vw,80vh); }
+      75%  { transform: translate(70vw,70vh); }
+      100% { transform: translate(0,0); }
+    }
+  </style>
+</head>
+<body>
+  <div class="message">Burn-in Repair Mode Active<br>(Click anywhere to return to dashboard)</div>
+  <script>
+    document.addEventListener('click', () => {
+      localStorage.setItem('burnInOverride', 'off');
+      const last = localStorage.getItem('lastPage') || '/index.html';
+      window.location.href = last;
+    });
+  </script>
+</body>
+</html>

--- a/public/burnin.js
+++ b/public/burnin.js
@@ -1,0 +1,38 @@
+(async function(){
+  await checkBurnIn();
+})();
+
+async function checkBurnIn() {
+  try {
+    const res = await fetch('/config.json', { cache: 'no-store' });
+    const cfg = await res.json();
+    const sched = cfg.burnInSchedule;
+    if (!sched) return false;
+    const override = localStorage.getItem('burnInOverride');
+    const now = new Date();
+    const [sh, sm] = sched.start.split(':').map(Number);
+    const [eh, em] = sched.end.split(':').map(Number);
+    const start = new Date();
+    start.setHours(sh, sm, 0, 0);
+    const end = new Date();
+    end.setHours(eh, em, 0, 0);
+    let inWindow;
+    if (start <= end) {
+      inWindow = now >= start && now < end;
+    } else {
+      inWindow = now >= start || now < end;
+    }
+    const shouldBurn = (inWindow && override !== 'off') || override === 'on';
+    if (shouldBurn && window.location.pathname !== '/burnin.html') {
+      localStorage.setItem('lastPage', window.location.pathname);
+      window.location.href = '/burnin.html';
+      return true;
+    }
+    return shouldBurn;
+  } catch (err) {
+    console.error('Burn-in check failed', err);
+    return false;
+  }
+}
+
+window.checkBurnIn = checkBurnIn;

--- a/public/config.json
+++ b/public/config.json
@@ -5,6 +5,10 @@
     "prodstatus.html"
   ],
   "interval": 30000,
+  "burnInSchedule": {
+    "start": "19:00",
+    "end": "05:00"
+  },
   "columns": {
     "index.html": [
       "locationID",

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
     <title>Work Order Breakdown</title>
     <link rel="stylesheet" href="style.css">
+    <script src="burnin.js"></script>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -386,7 +387,8 @@
             const pages = config.pages;
             const interval = config.interval || 15000;
             const next = pages[(pages.indexOf(page) + 1) % pages.length];
-            setTimeout(() => {
+            setTimeout(async () => {
+                if (await checkBurnIn()) return;
                 if (localStorage.getItem('rotationPaused') === 'true') return;
                 if (next && next !== page) window.location.href = '/' + next;
             }, interval);

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -3,6 +3,7 @@
 <head>
   <title>KPIs by Asset</title>
   <link rel="stylesheet" href="style.css">
+    <script src="burnin.js"></script>
   <style>
     body { font-family: Arial, sans-serif; margin:0; padding:0; background:#f0f0f0; color:#333; position:relative; }
     .top-border { position:fixed; top:0; left:0; width:100%; height:96px; background:rgba(146,208,80,1); z-index:2; display:flex; align-items:center; padding-right:20px; }
@@ -127,10 +128,11 @@
       const pages = config.pages;
       const interval = config.interval || 15000;
       const next = pages[(pages.indexOf(page) + 1) % pages.length];
-      setTimeout(() => {
-        if (localStorage.getItem('rotationPaused') === 'true') return;
-        if (next && next !== page) window.location.href = '/' + next;
-      }, interval);
+      setTimeout(async () => {
+                if (await checkBurnIn()) return;
+                if (localStorage.getItem('rotationPaused') === 'true') return;
+                if (next && next !== page) window.location.href = '/' + next;
+            }, interval);
     }
 
     function updateClock() {

--- a/public/pm.html
+++ b/public/pm.html
@@ -3,6 +3,7 @@
 <head>
     <title>Work Order Breakdown</title>
     <link rel="stylesheet" href="style.css">
+    <script src="burnin.js"></script>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -407,7 +408,8 @@
             const pages = config.pages;
             const interval = config.interval || 15000;
             const next = pages[(pages.indexOf(page) + 1) % pages.length];
-            setTimeout(() => {
+            setTimeout(async () => {
+                if (await checkBurnIn()) return;
                 if (localStorage.getItem('rotationPaused') === 'true') return;
                 if (next && next !== page) window.location.href = '/' + next;
             }, interval);

--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -3,6 +3,7 @@
 <head>
     <title>Work Order Breakdown</title>
     <link rel="stylesheet" href="style.css">
+    <script src="burnin.js"></script>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -423,7 +424,8 @@
             const pages = config.pages;
             const interval = config.interval || 15000;
             const next = pages[(pages.indexOf(page) + 1) % pages.length];
-            setTimeout(() => {
+            setTimeout(async () => {
+                if (await checkBurnIn()) return;
                 if (localStorage.getItem('rotationPaused') === 'true') return;
                 if (next && next !== page) window.location.href = '/' + next;
             }, interval);


### PR DESCRIPTION
## Summary
- add Burn-in Repair Mode page with drifting message and click-to-exit
- check burn-in schedule and overrides on each page before rotating
- add admin controls to manage burn-in schedule and overrides

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688eae6b13648326bbcf21aa8108bcf9