### PR TITLE
feat: warn when skipping server start in tests

### DIFF
--- a/server.js
+++ b/server.js
@@ -559,21 +559,28 @@ app.get('/api/kpis-by-asset', async (req, res) => {
   }
 });
 
-if (process.env.NODE_ENV !== 'test') {
-    app.listen(PORT, () => {
-        console.log(`Local:  http://localhost:${PORT}/`);
-        console.log(`On LAN: http://${ipv4}:${PORT}/`);
-        console.log(`NOICE! Server running at ${PORT}.`);
-    });
-    const refreshMs = cacheTtlSeconds * 1000;
-    setInterval(async () => {
-      await Promise.all([
-        app.fetchAndCache('kpis_overall', loadOverallKpis),
-        app.fetchAndCache('kpis_byAsset', loadByAssetKpis),
-        app.fetchAndCache('status', loadAssetStatus),
-      ]);
-      console.log('✅ Cache refreshed at', new Date().toISOString());
-    }, refreshMs);
+const shouldListen =
+  process.env.NODE_ENV !== 'test' || process.env.FORCE_LISTEN === 'true';
+
+if (shouldListen) {
+  app.listen(PORT, () => {
+    console.log(`Local:  http://localhost:${PORT}/`);
+    console.log(`On LAN: http://${ipv4}:${PORT}/`);
+    console.log(`NOICE! Server running at ${PORT}.`);
+  });
+  const refreshMs = cacheTtlSeconds * 1000;
+  setInterval(async () => {
+    await Promise.all([
+      app.fetchAndCache('kpis_overall', loadOverallKpis),
+      app.fetchAndCache('kpis_byAsset', loadByAssetKpis),
+      app.fetchAndCache('status', loadAssetStatus),
+    ]);
+    console.log('✅ Cache refreshed at', new Date().toISOString());
+  }, refreshMs);
+} else {
+  console.warn(
+    'Skipping app.listen because NODE_ENV is "test". Set FORCE_LISTEN=true to override.'
+  );
 }
 export { fetchAndCache, loadOverallKpis, loadByAssetKpis };
 export default app;


### PR DESCRIPTION
## Summary
- allow forcing the express server to start by setting `FORCE_LISTEN=true`
- log a warning when `NODE_ENV` is `test` so developers know why the server does not start

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68936f0dd3788326931627b1966c9923