### PR TITLE
Filter labor KPI entries by date

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -149,9 +149,11 @@ describe('KPI time range overrides', () => {
     expect(tasksUrl).not.toContain('dateCompletedGte');
     expect(tasksUrl).not.toContain('dateCompletedLte');
     const laborWeekUrl = fetchMock.mock.calls[1][0];
-    expect(laborWeekUrl).toContain('start=100');
+    expect(laborWeekUrl).toContain('/tasks/labor?assets=');
+    expect(laborWeekUrl).not.toContain('start=');
     const laborMonthUrl = fetchMock.mock.calls[2][0];
-    expect(laborMonthUrl).toContain('start=300');
+    expect(laborMonthUrl).toContain('/tasks/labor?assets=');
+    expect(laborMonthUrl).not.toContain('start=');
 
     delete process.env.KPI_WEEK_START;
     delete process.env.KPI_WEEK_END;
@@ -175,7 +177,8 @@ describe('KPI time range overrides', () => {
     expect(monthTasksUrl).not.toContain('dateCompletedGte');
     expect(monthTasksUrl).not.toContain('dateCompletedLte');
     const laborMonthUrl = fetchMock.mock.calls[1][0];
-    expect(laborMonthUrl).toContain('start=500');
+    expect(laborMonthUrl).toContain('/tasks/labor?assets=');
+    expect(laborMonthUrl).not.toContain('start=');
 
     delete process.env.KPI_MONTH_START;
     delete process.env.KPI_MONTH_END;


### PR DESCRIPTION
## Summary
- avoid 400 errors by removing `start` query param from labor API calls
- filter labor entries by date ranges for weekly and monthly KPI calculations
- adjust tests to new labor fetch behaviour

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68941635f2588326ba47255ca7becf52