### PR TITLE
Refactor header KPI logic into shared module

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -175,18 +175,18 @@
     <div class="top-border">
         <img src="img/pri-logo.png" alt="PRI Logo" class="logo">
         <div class="header-kpi">
-            <div class="kpi-title">Maintenance Uptime</div>
+            <div class="kpi-title">Maintenance Uptime (Last Week)</div>
             <div id="uptime-value" class="kpi-value">--%</div>
         </div>
         <div class="header-mt">
-            <div class="kpi-title">MTTR</div>
+            <div class="kpi-title">MTTR (30d)</div>
             <div id="mttr-value" class="kpi-value">--h</div>
-            <div class="kpi-title mtbf-title">MTBF</div>
+            <div class="kpi-title mtbf-title">MTBF (30d)</div>
             <div id="mtbf-value" class="kpi-value">--h</div>
         </div>
         <div id="clock"></div>
         <div class="header-kpi">
-            <div class="kpi-title">Planned vs Unplanned</div>
+            <div class="kpi-title">Planned vs Unplanned (Last Week)</div>
             <div id="planned-vs-unplanned" class="kpi-value">--% vs --%</div>
         </div>
     </div>
@@ -378,26 +378,10 @@
     }
     setInterval(updateClock, 1000);
     updateClock();
-
-    // overall KPIs
-    async function updateKPIs() {
-        try {
-            const res = await fetch('/api/kpis');
-            const { overall: k } = await res.json();
-            document.getElementById('uptime-value').innerText       = k.uptimePct + '%';
-            document.getElementById('mttr-value').innerText         = k.mttrHrs   + 'h';
-            document.getElementById('mtbf-value').innerText         = k.mtbfHrs   + 'h';
-            const total = k.plannedCount + k.unplannedCount;
-            const plannedPct   = total ? ((k.plannedCount/total)*100).toFixed(0)   + '%' : '0%';
-            const unplannedPct = total ? ((k.unplannedCount/total)*100).toFixed(0) + '%' : '0%';
-            document.getElementById('planned-vs-unplanned').innerText =
-                `${plannedPct} vs ${unplannedPct}`;
-        } catch (err) {
-            console.error('Failed to load KPIs', err);
-        }
-    }
-    updateKPIs();
-    setInterval(updateKPIs, 15 * 60 * 1000);
+</script>
+<script type="module">
+    import { initHeaderKPIs } from './js/header-kpis.js';
+    initHeaderKPIs();
 </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -488,28 +488,12 @@
     document.getElementById('clock').innerHTML =
       `<span class="clock-date">${dateFmt.format(now)}</span>${timeFmt.format(now)}`;
   }
-  setInterval(updateClock, 1000);
-  updateClock();
-
-  // overall KPIs
-  async function updateKPIs() {
-    try {
-      const res = await fetch('/api/kpis');
-      const { overall: k } = await res.json();
-      document.getElementById('uptime-value').innerText       = k.uptimePct + '%';
-      document.getElementById('mttr-value').innerText         = k.mttrHrs   + 'h';
-      document.getElementById('mtbf-value').innerText         = k.mtbfHrs   + 'h';
-      const total = k.plannedCount + k.unplannedCount;
-      const plannedPct   = total ? ((k.plannedCount/total)*100).toFixed(0)   + '%' : '0%';
-      const unplannedPct = total ? ((k.unplannedCount/total)*100).toFixed(0) + '%' : '0%';
-      document.getElementById('planned-vs-unplanned').innerText =
-        `${plannedPct} vs ${unplannedPct}`;
-    } catch (err) {
-      console.error('Failed to load KPIs', err);
-    }
-  }
-  updateKPIs();
-  setInterval(updateKPIs, 15 * 60 * 1000);
+    setInterval(updateClock, 1000);
+    updateClock();
+</script>
+<script type="module">
+  import { initHeaderKPIs } from './js/header-kpis.js';
+  initHeaderKPIs();
 </script>
 </body>
 </html>

--- a/public/js/header-kpis.js
+++ b/public/js/header-kpis.js
@@ -1,0 +1,27 @@
+// public/js/header-kpis.js
+export async function initHeaderKPIs() {
+  const uptimeEl   = document.getElementById('uptime-value');
+  const mttrEl     = document.getElementById('mttr-value');
+  const mtbfEl     = document.getElementById('mtbf-value');
+  const planUnplan = document.getElementById('planned-vs-unplanned');
+
+  async function update() {
+    try {
+      const res = await fetch('/api/kpis/header');
+      if (!res.ok) throw new Error(await res.text());
+      const k = await res.json();
+      uptimeEl.innerText   = `${k.uptimePct}%`;
+      mttrEl.innerText     = `${k.mttrHrs}h`;
+      mtbfEl.innerText     = `${k.mtbfHrs}h`;
+      const total = k.plannedCount + k.unplannedCount;
+      const pPct = total ? ((k.plannedCount/total)*100).toFixed(0)   : '0';
+      const uPct = total ? ((k.unplannedCount/total)*100).toFixed(0) : '0';
+      planUnplan.innerText = `${pPct}% vs ${uPct}%`;
+    } catch (err) {
+      console.error('Header KPI fetch failed:', err);
+    }
+  }
+
+  update();
+  setInterval(update, 15 * 60 * 1000);
+}

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -167,5 +167,9 @@
     updateClock();
 
   </script>
+  <script type="module">
+    import { initHeaderKPIs } from './js/header-kpis.js';
+    initHeaderKPIs();
+  </script>
 </body>
 </html>

--- a/public/pm.html
+++ b/public/pm.html
@@ -489,28 +489,12 @@
     document.getElementById('clock').innerHTML =
       `<span class="clock-date">${dateFmt.format(now)}</span>${timeFmt.format(now)}`;
   }
-  setInterval(updateClock, 1000);
-  updateClock();
-
-  // overall KPIs
-  async function updateKPIs() {
-    try {
-      const res = await fetch('/api/kpis');
-      const { overall: k } = await res.json();
-      document.getElementById('uptime-value').innerText       = k.uptimePct + '%';
-      document.getElementById('mttr-value').innerText         = k.mttrHrs   + 'h';
-      document.getElementById('mtbf-value').innerText         = k.mtbfHrs   + 'h';
-      const total = k.plannedCount + k.unplannedCount;
-      const plannedPct   = total ? ((k.plannedCount/total)*100).toFixed(0)   + '%' : '0%';
-      const unplannedPct = total ? ((k.unplannedCount/total)*100).toFixed(0) + '%' : '0%';
-      document.getElementById('planned-vs-unplanned').innerText =
-        `${plannedPct} vs ${unplannedPct}`;
-    } catch (err) {
-      console.error('Failed to load KPIs', err);
-    }
-  }
-  updateKPIs();
-  setInterval(updateKPIs, 15 * 60 * 1000);
+    setInterval(updateClock, 1000);
+    updateClock();
+</script>
+<script type="module">
+  import { initHeaderKPIs } from './js/header-kpis.js';
+  initHeaderKPIs();
 </script>
 </body>
 </html>

--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -572,28 +572,12 @@
     document.getElementById('clock').innerHTML =
       `<span class="clock-date">${dateFmt.format(now)}</span>${timeFmt.format(now)}`;
   }
-  setInterval(updateClock, 1000);
-  updateClock();
-
-  // overall KPIs
-  async function updateKPIs() {
-    try {
-      const res = await fetch('/api/kpis');
-      const { overall: k } = await res.json();
-      document.getElementById('uptime-value').innerText       = k.uptimePct + '%';
-      document.getElementById('mttr-value').innerText         = k.mttrHrs   + 'h';
-      document.getElementById('mtbf-value').innerText         = k.mtbfHrs   + 'h';
-      const total = k.plannedCount + k.unplannedCount;
-      const plannedPct   = total ? ((k.plannedCount/total)*100).toFixed(0)   + '%' : '0%';
-      const unplannedPct = total ? ((k.unplannedCount/total)*100).toFixed(0) + '%' : '0%';
-      document.getElementById('planned-vs-unplanned').innerText =
-        `${plannedPct} vs ${unplannedPct}`;
-    } catch (err) {
-      console.error('Failed to load KPIs', err);
-    }
-  }
-  updateKPIs();
-  setInterval(updateKPIs, 15 * 60 * 1000);
+    setInterval(updateClock, 1000);
+    updateClock();
+</script>
+<script type="module">
+  import { initHeaderKPIs } from './js/header-kpis.js';
+  initHeaderKPIs();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `header-kpis.js` ES module to fetch and refresh header metrics
- load the module across index, admin, PM, production status, and KPI-by-asset pages
- align admin page header KPI markup with other pages

## Testing
- `npm test`
- `npm run lint`
- `node --input-type=module < smoke.js` (jsdom smoke test)


------
https://chatgpt.com/codex/tasks/task_e_689509bd21e48326b623d5412a74773f