### PR TITLE
Refactor header KPI updater for global use

### DIFF
--- a/public/js/header-kpis.js
+++ b/public/js/header-kpis.js
@@ -1,27 +1,26 @@
 // public/js/header-kpis.js
-export async function initHeaderKPIs() {
-  const uptimeEl   = document.getElementById('uptime-value');
-  const mttrEl     = document.getElementById('mttr-value');
-  const mtbfEl     = document.getElementById('mtbf-value');
-  const planUnplan = document.getElementById('planned-vs-unplanned');
-
-  async function update() {
-    try {
-      const res = await fetch('/api/kpis/header');
-      if (!res.ok) throw new Error(await res.text());
-      const k = await res.json();
-      uptimeEl.innerText   = `${k.uptimePct}%`;
-      mttrEl.innerText     = `${k.mttrHrs}h`;
-      mtbfEl.innerText     = `${k.mtbfHrs}h`;
-      const total = k.plannedCount + k.unplannedCount;
-      const pPct = total ? ((k.plannedCount/total)*100).toFixed(0)   : '0';
-      const uPct = total ? ((k.unplannedCount/total)*100).toFixed(0) : '0';
-      planUnplan.innerText = `${pPct}% vs ${uPct}%`;
-    } catch (err) {
-      console.error('Header KPI fetch failed:', err);
-    }
+async function _updateHeader() {
+  try {
+    const res = await fetch('/api/kpis/header');
+    if (!res.ok) throw new Error(await res.text());
+    const k = await res.json();
+    document.getElementById('uptime-value').innerText   = `${k.uptimePct}%`;
+    document.getElementById('mttr-value').innerText     = `${k.mttrHrs}h`;
+    document.getElementById('mtbf-value').innerText     = `${k.mtbfHrs}h`;
+    const total = k.plannedCount + k.unplannedCount;
+    const pPct  = total ? ((k.plannedCount/total)*100).toFixed(0)   : '0';
+    const uPct  = total ? ((k.unplannedCount/total)*100).toFixed(0) : '0';
+    document.getElementById('planned-vs-unplanned').innerText =
+      `${pPct}% vs ${uPct}%`;
+  } catch (err) {
+    console.error('Header KPI fetch failed:', err);
   }
-
-  update();
-  setInterval(update, 15 * 60 * 1000);
 }
+
+export async function initHeaderKPIs() {
+  _updateHeader();
+  setInterval(_updateHeader, 15 * 60 * 1000);
+}
+
+// expose for global use
+window.updateKPIs = _updateHeader;


### PR DESCRIPTION
## Summary
- extract header KPI update logic into new async `_updateHeader`
- call `_updateHeader` in `initHeaderKPIs` and set refresh interval
- expose `_updateHeader` globally via `window.updateKPIs`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68952b92db148326b282c4dea6d8823d