### PR TITLE
Handle non-JSON weather API responses

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -337,9 +337,15 @@
         }
 
         function fetchWeather() {
-            fetch('https://wttr.in/Indianapolis?format=j1')
-                .then(res => res.json())
-                .then(data => {
+            fetch('https://wttr.in/Indianapolis?format=j1&' + Date.now())
+                .then(res => res.text())
+                .then(text => {
+                    let data;
+                    try {
+                        data = JSON.parse(text);
+                    } catch (err) {
+                        throw new Error('Invalid weather response');
+                    }
                     const container = document.getElementById('weather-container');
                     container.innerHTML = '';
                     const alerts = [];
@@ -363,7 +369,11 @@
                     });
                     displayAlerts(alerts);
                 })
-                .catch(err => console.error('Weather error', err));
+                .catch(err => {
+                    console.error('Weather error', err);
+                    const container = document.getElementById('weather-container');
+                    container.innerHTML = '<div>Weather data unavailable</div>';
+                });
         }
         fetchWeather();
 

--- a/public/pm.html
+++ b/public/pm.html
@@ -338,9 +338,15 @@
         }
 
         function fetchWeather() {
-            fetch('https://wttr.in/Indianapolis?format=j1')
-                .then(res => res.json())
-                .then(data => {
+            fetch('https://wttr.in/Indianapolis?format=j1&' + Date.now())
+                .then(res => res.text())
+                .then(text => {
+                    let data;
+                    try {
+                        data = JSON.parse(text);
+                    } catch (err) {
+                        throw new Error('Invalid weather response');
+                    }
                     const container = document.getElementById('weather-container');
                     container.innerHTML = '';
                     const alerts = [];
@@ -364,7 +370,11 @@
                     });
                     displayAlerts(alerts);
                 })
-                .catch(err => console.error('Weather error', err));
+                .catch(err => {
+                    console.error('Weather error', err);
+                    const container = document.getElementById('weather-container');
+                    container.innerHTML = '<div>Weather data unavailable</div>';
+                });
         }
         fetchWeather();
 

--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -373,9 +373,15 @@
         }
 
         function fetchWeather() {
-            fetch('https://wttr.in/Indianapolis?format=j1')
-                .then(res => res.json())
-                .then(data => {
+            fetch('https://wttr.in/Indianapolis?format=j1&' + Date.now())
+                .then(res => res.text())
+                .then(text => {
+                    let data;
+                    try {
+                        data = JSON.parse(text);
+                    } catch (err) {
+                        throw new Error('Invalid weather response');
+                    }
                     const container = document.getElementById('weather-container');
                     container.innerHTML = '';
                     const alerts = [];
@@ -399,7 +405,11 @@
                     });
                     displayAlerts(alerts);
                 })
-                .catch(err => console.error('Weather error', err));
+                .catch(err => {
+                    console.error('Weather error', err);
+                    const container = document.getElementById('weather-container');
+                    container.innerHTML = '<div>Weather data unavailable</div>';
+                });
         }
         fetchWeather();
 


### PR DESCRIPTION
## Summary
- avoid wttr.in cache by appending timestamp to weather request
- parse weather response defensively and show message if JSON is invalid

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68952ec2cf048326a6bf93a40a864e8c