### PR TITLE
Fix KPI labor fetch and expose header update hook

### DIFF
--- a/public/js/header-kpis.js
+++ b/public/js/header-kpis.js
@@ -1,40 +1,28 @@
 // public/js/header-kpis.js
 
-// Cache DOM elements for header KPIs
-const uptimeEl   = document.getElementById('uptime-value');
-const mttrEl     = document.getElementById('mttr-value');
-const mtbfEl     = document.getElementById('mtbf-value');
-const planUnplan = document.getElementById('planned-vs-unplanned');
-
-/**
- * Fetch and update the header KPI values from the server.
- */
 async function _updateHeader() {
   try {
     const res = await fetch('/api/kpis/header');
     if (!res.ok) throw new Error(await res.text());
     const k = await res.json();
-
-    uptimeEl.innerText   = `${k.uptimePct}%`;
-    mttrEl.innerText     = `${k.mttrHrs}h`;
-    mtbfEl.innerText     = `${k.mtbfHrs}h`;
-
-    const total  = k.plannedCount + k.unplannedCount;
-    const pPct   = total ? ((k.plannedCount / total) * 100).toFixed(0) : '0';
-    const uPct   = total ? ((k.unplannedCount / total) * 100).toFixed(0) : '0';
-    planUnplan.innerText = `${pPct}% vs ${uPct}%`;
+    document.getElementById('uptime-value').innerText   = `${k.uptimePct}%`;
+    document.getElementById('mttr-value').innerText     = `${k.mttrHrs}h`;
+    document.getElementById('mtbf-value').innerText     = `${k.mtbfHrs}h`;
+    const total = k.plannedCount + k.unplannedCount;
+    const pPct  = total ? ((k.plannedCount/total)*100).toFixed(0)   : '0';
+    const uPct  = total ? ((k.unplannedCount/total)*100).toFixed(0) : '0';
+    document.getElementById('planned-vs-unplanned').innerText =
+      `${pPct}% vs ${uPct}%`;
   } catch (err) {
     console.error('Header KPI fetch failed:', err);
   }
 }
 
-/**
- * Initialize periodic updates for the header KPIs.
- */
 export function initHeaderKPIs() {
   _updateHeader();
   setInterval(_updateHeader, 15 * 60 * 1000);
 }
 
-// Expose updateKPIs globally so other scripts can manually refresh
+// expose for global use in other modules
 window.updateKPIs = _updateHeader;
+

--- a/server.js
+++ b/server.js
@@ -119,28 +119,16 @@ async function loadOverallKpis() {
     console.log(
       `   ↳ Filtering labor week entries: ${weekStart.toISOString()} to ${weekEnd.toISOString()}`
     );
-    const laborAllRes = await fetch(`${API_V2}/tasks/labor?limit=10000`, { headers });
-    if (!laborAllRes.ok) {
-      const body = await laborAllRes.text();
-      console.error(`loadOverallKpis labor week error for ${id}:`, laborAllRes.status);
-      throw new Error(`Labor week ${laborAllRes.status}: ${body}`);
-    }
-    const laborAll = (await laborAllRes.json()).data?.entries || [];
-    const filteredWeek = laborAll.filter(e =>
-      e.assetID === id &&
-      e.dateLogged >= weekStart.unix() &&
-      e.dateLogged <= weekEnd.unix()
+    const laborWeekRes = await fetch(
+      `${API_V2}/tasks/labor?assets=${id}&start=${weekStart.unix()}&end=${weekEnd.unix()}`,
+      { headers }
     );
     let entriesWeek = [];
-    try {
-      if (!laborWeekRes.ok) {
-        console.warn(`Asset ${id} labor week returned ${laborWeekRes.status}, treating as zero.`);
-      } else {
-        const laborWeekJson = await laborWeekRes.json();
-        entriesWeek = laborWeekJson.data?.entries || laborWeekJson.entries || [];
-      }
-    } catch (err) {
-      console.error(`Error parsing labor week for ${id}:`, err);
+    if (laborWeekRes.ok) {
+      const json = await laborWeekRes.json();
+      entriesWeek = json.data?.entries || json.entries || [];
+    } else {
+      console.warn(`Asset ${id} labor week returned ${laborWeekRes.status}, treating as zero.`);
     }
     const downtimeSec = entriesWeek
       .filter(e => e.downtime)
@@ -154,28 +142,16 @@ async function loadOverallKpis() {
     console.log(
       `   ↳ Filtering labor month entries: ${monthStart.toISOString()} to ${monthEnd.toISOString()}`
     );
-    const laborAllMonthRes = await fetch(`${API_V2}/tasks/labor?limit=10000`, { headers });
-    if (!laborAllMonthRes.ok) {
-      const body = await laborAllMonthRes.text();
-      console.error(`loadOverallKpis labor month error for ${id}:`, laborAllMonthRes.status);
-      throw new Error(`Labor month ${laborAllMonthRes.status}: ${body}`);
-    }
-    const laborAllMonth = (await laborAllMonthRes.json()).data?.entries || [];
-    const filteredMonth = laborAllMonth.filter(e =>
-      e.assetID === id &&
-      e.dateLogged >= monthStart.unix() &&
-      e.dateLogged <= monthEnd.unix()
+    const laborMonthRes = await fetch(
+      `${API_V2}/tasks/labor?assets=${id}&start=${monthStart.unix()}&end=${monthEnd.unix()}`,
+      { headers }
     );
     let entriesMonth = [];
-    try {
-      if (!laborMonthRes.ok) {
-        console.warn(`Asset ${id} labor month returned ${laborMonthRes.status}, treating as zero.`);
-      } else {
-        const laborMonthJson = await laborMonthRes.json();
-        entriesMonth = laborMonthJson.data?.entries || laborMonthJson.entries || [];
-      }
-    } catch (err) {
-      console.error(`Error parsing labor month for ${id}:`, err);
+    if (laborMonthRes.ok) {
+      const json = await laborMonthRes.json();
+      entriesMonth = json.data?.entries || json.entries || [];
+    } else {
+      console.warn(`Asset ${id} labor month returned ${laborMonthRes.status}, treating as zero.`);
     }
     totals.downtimeMinutes += entriesMonth
       .filter(e => e.downtime && e.taskType === 'wo')


### PR DESCRIPTION
## Summary
- Fetch labor week and month KPIs with asset-specific date ranges to avoid undefined variables
- Streamline header KPI updater and expose global refresh function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68953d536a548326b700521fbef3d0c5