### PR TITLE
Remove labor assets filter and standardize header KPIs

### DIFF
--- a/public/js/header-kpis.js
+++ b/public/js/header-kpis.js
@@ -23,6 +23,6 @@ export function initHeaderKPIs() {
   setInterval(_updateHeader, 15 * 60 * 1000);
 }
 
-// expose for global use in other modules
+// expose for global use
 window.updateKPIs = _updateHeader;
 

--- a/public/js/kpi-by-asset.js
+++ b/public/js/kpi-by-asset.js
@@ -1,5 +1,3 @@
-import { initHeaderKPIs, updateKPIs } from './header-kpis.js';
-
 let mappings;
 await fetch('/mappings.json')
   .then(r => r.json())
@@ -12,8 +10,6 @@ const tbody     = document.querySelector('#kpi-by-asset tbody');
 const selectEl  = document.getElementById('timeframe-select');
 
 console.log('[kpi-by-asset.js] module loaded');
-initHeaderKPIs();  // sets up header refresh
-updateKPIs();      // initial kick-off
 
 selectEl.addEventListener('change', () => loadAll());
 

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -123,6 +123,10 @@
     </table>
 
   </div>
+  <script type="module">
+    import { initHeaderKPIs } from './js/header-kpis.js';
+    initHeaderKPIs();
+  </script>
   <script type="module" src="/js/kpi-by-asset.js"></script>
   <script>
     const rotateBtn = document.getElementById('toggle-rotation');

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -149,11 +149,13 @@ describe('KPI time range overrides', () => {
     expect(tasksUrl).not.toContain('dateCompletedGte');
     expect(tasksUrl).not.toContain('dateCompletedLte');
     const laborWeekUrl = fetchMock.mock.calls[1][0];
-    expect(laborWeekUrl).toContain('/tasks/labor?assets=');
+    expect(laborWeekUrl).toContain('/tasks/labor?');
+    expect(laborWeekUrl).toContain('limit=10000');
     expect(laborWeekUrl).toContain('start=100');
     expect(laborWeekUrl).toContain('end=200');
     const laborMonthUrl = fetchMock.mock.calls[2][0];
-    expect(laborMonthUrl).toContain('/tasks/labor?assets=');
+    expect(laborMonthUrl).toContain('/tasks/labor?');
+    expect(laborMonthUrl).toContain('limit=10000');
     expect(laborMonthUrl).toContain('start=300');
     expect(laborMonthUrl).toContain('end=400');
 


### PR DESCRIPTION
## Summary
- Drop unsupported `assets` filter from labor queries in `loadOverallKpis`, request a large range, and filter results in code
- Share header KPI initialization script across all pages and expose global updater
- Adjust KPI test expectations for new labor URLs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689542c8a404832696fd1124662d6c8f