### PR TITLE
Wire timeframe selection through KPI by asset API

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,13 @@ The admin interface is available at `http://<LOCAL_IP>:<PORT>/admin`.
   (see [KPI time ranges](#kpi-time-ranges)). When unset, the server uses the
   last calendar week and previous calendar month.
 * Per-asset metrics are returned alongside the overall values from `/api/kpis`.
+
+### KPIs by Asset timeframe
+The page `/kpi-by-asset.html` controls the date range via the “Timeframe” dropdown.
+The frontend calls `/api/kpis/by-asset?timeframe=...` where the values are:
+- currentWeek (Mon–Sun via ISO week), lastWeek
+- currentMonth, lastMonth
+- currentYear, lastYear
+
+The server computes `{start, end}` using moment and returns KPIs for that range.
+Results are cached per timeframe key.


### PR DESCRIPTION
## Summary
- Frontend now sends `timeframe` query for KPI-by-asset and reloads on dropdown changes
- Server computes date ranges by timeframe, caches per-key, and wires `/api/kpis/by-asset`
- Document KPI timeframe options and caching behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689561beba188326a55a3d55b2ae9b19