### PR TITLE
Show KPI data loading spinner

### DIFF
--- a/public/js/kpi-by-asset.js
+++ b/public/js/kpi-by-asset.js
@@ -19,7 +19,7 @@ export async function loadAll() {
   const loadingEl = document.getElementById('loading');
   const errorEl   = document.getElementById('error-banner');
 
-  if (loadingEl) loadingEl.style.display = 'block';
+  if (loadingEl) loadingEl.style.display = 'flex';
   if (errorEl)   errorEl.style.display = 'none';
   try {
     const res = await fetch(`/api/kpis/by-asset?timeframe=${encodeURIComponent(tf)}`);

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -71,7 +71,9 @@
       <span id="refresh-timer"></span>
     </div>
     <div id="error-banner" style="display:none;color:red;">Failed to load KPIs</div>
-    <div id="loading" style="display:none;">Loading...</div>
+    <div id="loading" style="display:none;">
+      <div class="spinner"></div>
+    </div>
     <div>
       <label for="timeframe-select">Timeframe:</label>
       <select id="timeframe-select">

--- a/public/style.css
+++ b/public/style.css
@@ -68,3 +68,31 @@
     border: 1px solid ButtonText;
   }
 }
+
+/* loading spinner overlay */
+#loading {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.7);
+  z-index: 9999;
+}
+
+#loading .spinner {
+  border: 8px solid #f3f3f3;
+  border-top: 8px solid #3498db;
+  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
- Add overlay spinner element to KPI by asset page to indicate server-side data loads
- Style shared spinner overlay and animate with CSS
- Update KPI data loader to reveal spinner while fetching

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895cfdbf544832685e5d54c6ef604c9