### PR TITLE
Add true overall KPI tiles and fix header KPI sourcing

### DIFF
--- a/public/js/compute-true-overall.js
+++ b/public/js/compute-true-overall.js
@@ -1,0 +1,47 @@
+import { getHeaderKpisCache } from './header-kpis.js';
+
+/**
+ * Compute true overall KPIs for the by-asset payload.
+ * Prefers additive totals from payload.totals, falls back to summing per-asset fields.
+ * For uptimePct, if we cannot compute due to missing hours, fall back to
+ * headerKpisCache.overall.uptimePct so the tile never shows blank.
+ * @param {object} data - payload from /api/kpis/by-asset
+ * @returns {{uptimePct: number|null, mttrHrs: number|null, mtbfHrs: number|null, plannedPct: number|null, unplannedPct: number|null}}
+ */
+export function computeTrueOverall(data = {}) {
+  const assets = data.assets || {};
+  const totals = data.totals || {};
+
+  const sumField = (field) => {
+    if (typeof totals[field] === 'number') return totals[field];
+    return Object.values(assets).reduce((sum, a) => sum + (a[field] || 0), 0);
+  };
+
+  const downtime = sumField('downtimeHrs');
+  const scheduled = sumField('scheduledHrs');
+  const repair = sumField('repairHrs');
+  const runtime = sumField('runtimeHrs');
+  const failures = sumField('failureCount') || sumField('unplannedCount');
+  const planned = sumField('plannedCount');
+  const unplanned = sumField('unplannedCount');
+
+  const totalWo = planned + unplanned;
+
+  let uptimePct = null;
+  if (scheduled > 0) {
+    uptimePct = (1 - (downtime / scheduled)) * 100;
+  } else {
+    // Fallback to server computed overall uptime so tile never blank
+    const cached = getHeaderKpisCache();
+    if (cached && typeof cached.overall?.uptimePct === 'number') {
+      uptimePct = cached.overall.uptimePct;
+    }
+  }
+
+  const mttr = failures > 0 ? (repair / failures) : null;
+  const mtbf = failures > 0 ? (runtime / failures) : null;
+  const plannedPct = totalWo > 0 ? (planned / totalWo) * 100 : null;
+  const unplannedPct = totalWo > 0 ? (unplanned / totalWo) * 100 : null;
+
+  return { uptimePct, mttrHrs: mttr, mtbfHrs: mtbf, plannedPct, unplannedPct };
+}

--- a/public/js/header-kpis.js
+++ b/public/js/header-kpis.js
@@ -1,28 +1,48 @@
 // public/js/header-kpis.js
 
+let headerKpisCache;
+let initialFetchPromise;
+
+function renderHeader(overall = {}) {
+  const uptimeEl   = document.getElementById('uptime-value');
+  const mttrEl     = document.getElementById('mttr-value');
+  const mtbfEl     = document.getElementById('mtbf-value');
+  const pvupEl     = document.getElementById('planned-vs-unplanned');
+
+  if (uptimeEl) uptimeEl.innerText = `${overall.uptimePct ?? '--'}%`;
+  if (mttrEl)   mttrEl.innerText   = `${overall.mttrHrs ?? '--'}h`;
+  if (mtbfEl)   mtbfEl.innerText   = `${overall.mtbfHrs ?? '--'}h`;
+
+  const total = (overall.plannedCount || 0) + (overall.unplannedCount || 0);
+  const pPct  = total ? ((overall.plannedCount / total) * 100).toFixed(0)   : '--';
+  const uPct  = total ? ((overall.unplannedCount / total) * 100).toFixed(0) : '--';
+  if (pvupEl) pvupEl.innerText = `${pPct}% vs ${uPct}%`;
+}
+
 async function _updateHeader() {
   try {
-    const res = await fetch('/api/kpis/header');
+    const res = await fetch('/api/kpis');
     if (!res.ok) throw new Error(await res.text());
-    const k = await res.json();
-    document.getElementById('uptime-value').innerText   = `${k.uptimePct}%`;
-    document.getElementById('mttr-value').innerText     = `${k.mttrHrs}h`;
-    document.getElementById('mtbf-value').innerText     = `${k.mtbfHrs}h`;
-    const total = k.plannedCount + k.unplannedCount;
-    const pPct  = total ? ((k.plannedCount/total)*100).toFixed(0)   : '0';
-    const uPct  = total ? ((k.unplannedCount/total)*100).toFixed(0) : '0';
-    document.getElementById('planned-vs-unplanned').innerText =
-      `${pPct}% vs ${uPct}%`;
+    const data = await res.json();
+    headerKpisCache = data;
+    renderHeader(data.overall);
   } catch (err) {
     console.error('Header KPI fetch failed:', err);
   }
 }
 
 export function initHeaderKPIs() {
-  _updateHeader();
+  initialFetchPromise = _updateHeader();
   setInterval(_updateHeader, 15 * 60 * 1000);
+}
+
+export function getHeaderKpisCache() {
+  return headerKpisCache;
+}
+
+export function headerKpisReady() {
+  return initialFetchPromise || Promise.resolve();
 }
 
 // expose for global use
 window.updateKPIs = _updateHeader;
-

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -132,6 +132,29 @@
     </tfoot>
     </table>
     </div>
+    <h2>All Assets — True Overall</h2>
+    <div id="true-overall-row">
+      <div class="kpi-tile">
+        <div class="kpi-title">Uptime %</div>
+        <div class="kpi-value" data-testid="true-overall-uptime">--%</div>
+      </div>
+      <div class="kpi-tile">
+        <div class="kpi-title">MTTR (h)</div>
+        <div class="kpi-value" data-testid="true-overall-mttr">--</div>
+      </div>
+      <div class="kpi-tile">
+        <div class="kpi-title">MTBF (h)</div>
+        <div class="kpi-value" data-testid="true-overall-mtbf">--</div>
+      </div>
+      <div class="kpi-tile">
+        <div class="kpi-title">Planned %</div>
+        <div class="kpi-value" data-testid="true-overall-planned">--%</div>
+      </div>
+      <div class="kpi-tile">
+        <div class="kpi-title">Unplanned %</div>
+        <div class="kpi-value" data-testid="true-overall-unplanned">--%</div>
+      </div>
+    </div>
 
   </div>
   <script type="module">

--- a/public/style.css
+++ b/public/style.css
@@ -53,6 +53,23 @@
 #kpi-by-asset tfoot tr { position: sticky; bottom: 0; background: #f8fafc; z-index: 1; }
 #kpi-by-asset tfoot td { background: #f8fafc; } /* ensure solid bg over rows */
 
+/* True Overall tiles */
+#true-overall-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 20px;
+}
+#true-overall-row .kpi-tile {
+  flex: 1 1 180px;
+  background: #f8fafc;
+  padding: 10px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  text-align: center;
+}
+#true-overall-row .kpi-value { font-variant-numeric: tabular-nums; }
+
 /* === Timeframe label and select sizing for KPI-by-Asset page === */
 label[for="timeframe-select"] {
   font-size: 2em;        /* Twice normal size */

--- a/server.js
+++ b/server.js
@@ -314,7 +314,9 @@ async function loadByAssetKpis({ start, end }) {
 
     const tasksRes = await fetch(byAssetUrl, { headers });
     if (!tasksRes.ok) {
-      const body = await tasksRes.text().catch(() => '');
+      const body = typeof tasksRes.text === 'function'
+        ? await tasksRes.text().catch(() => '')
+        : '';
       console.error('loadByAssetKpis tasks error:', tasksRes.status);
       throw new Error(`loadByAssetKpis tasks error: ${tasksRes.status}: ${body}`);
     }


### PR DESCRIPTION
## Summary
- show true overall KPIs aggregated from by-asset data
- cache header KPI metrics from `/api/kpis` so they remain fixed
- harden backend task error handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689610d790188326a3b567727d50616d