### PR TITLE
feat: show downtime hours and initial date range

### DIFF
--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -80,20 +80,21 @@
         <option value="currentWeek">Current Week</option>
         <option value="lastWeek">Last Week</option>
         <option value="currentMonth">Current Month</option>
-        <option value="lastMonth">Last Month</option>
+        <option value="lastMonth" selected>Last Month</option>
         <option value="currentYear">Current Year</option>
         <option value="lastYear">Last Year</option>
         <option value="trailing7Days">Trailing 7 Days</option>
         <option value="trailing30Days">Trailing 30 Days</option>
         <option value="trailing12Months">Trailing 12 Months</option>
       </select>
-      <span id="timeframe-range" style="margin-left:8px; opacity:.8;"></span>
+      <span id="date-range" style="margin-left:8px; opacity:.8;"></span>
     </div>
     <div class="table-wrap">
     <table id="kpi-by-asset">
       <thead>
         <tr>
           <th>Asset Name</th>
+          <th class="col-downtime" data-testid="col-downtime-hrs">Downtime Hrs</th>
           <th>Uptime %</th>
           <th>MTTR</th>
           <th>MTBF</th>
@@ -107,6 +108,10 @@
         <td class="kpi-cell">
           <div class="kpi-title">Total Assets</div>
           <div id="total-assets" class="kpi-value">--</div>
+        </td>
+        <td class="kpi-cell">
+          <div class="kpi-title">Avg Downtime Hrs</div>
+          <div id="avg-downtime" class="kpi-value">--</div>
         </td>
         <td class="kpi-cell">
           <div class="kpi-title">Avg Uptime %</div>

--- a/public/style.css
+++ b/public/style.css
@@ -53,6 +53,12 @@
 #kpi-by-asset tfoot tr { position: sticky; bottom: 0; background: #f8fafc; z-index: 1; }
 #kpi-by-asset tfoot td { background: #f8fafc; } /* ensure solid bg over rows */
 
+/* narrow downtime column to avoid wrapping */
+#kpi-by-asset th.col-downtime,
+#kpi-by-asset td.col-downtime {
+  white-space: nowrap;
+}
+
 /* True Overall tiles */
 #true-overall-row {
   display: flex;


### PR DESCRIPTION
## Summary
- add Downtime Hrs column in KPI-by-asset table and compute averages
- initialize timeframe/date range label on first load with helper
- style downtime column to avoid wrapping

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68961fbab2f083268d94a689b5c9006f