### PR TITLE
Align header KPIs with by-asset calculations

### DIFF
--- a/public/js/header-kpis.js
+++ b/public/js/header-kpis.js
@@ -1,31 +1,60 @@
 // public/js/header-kpis.js
 
+import { computeTrueOverall } from './compute-true-overall.js';
+
 let headerKpisCache;
 let initialFetchPromise;
 
-function renderHeader(overall = {}) {
-  const uptimeEl   = document.getElementById('uptime-value');
-  const mttrEl     = document.getElementById('mttr-value');
-  const mtbfEl     = document.getElementById('mtbf-value');
-  const pvupEl     = document.getElementById('planned-vs-unplanned');
+function renderHeader(kpis = {}) {
+  const uptimeEl = document.getElementById('uptime-value');
+  const mttrEl   = document.getElementById('mttr-value');
+  const mtbfEl   = document.getElementById('mtbf-value');
+  const pvupEl   = document.getElementById('planned-vs-unplanned');
 
-  if (uptimeEl) uptimeEl.innerText = `${overall.uptimePct ?? '--'}%`;
-  if (mttrEl)   mttrEl.innerText   = `${overall.mttrHrs ?? '--'}h`;
-  if (mtbfEl)   mtbfEl.innerText   = `${overall.mtbfHrs ?? '--'}h`;
+  const uptime = kpis.lastWeek?.uptimePct;
+  const mttr   = kpis.trailing30Days?.mttrHrs;
+  const mtbf   = kpis.trailing30Days?.mtbfHrs;
+  const pPct   = kpis.lastWeek?.plannedPct;
+  const uPct   = kpis.lastWeek?.unplannedPct;
 
-  const total = (overall.plannedCount || 0) + (overall.unplannedCount || 0);
-  const pPct  = total ? ((overall.plannedCount / total) * 100).toFixed(0)   : '--';
-  const uPct  = total ? ((overall.unplannedCount / total) * 100).toFixed(0) : '--';
-  if (pvupEl) pvupEl.innerText = `${pPct}% vs ${uPct}%`;
+  if (uptimeEl) uptimeEl.innerText = uptime != null ? `${uptime.toFixed(1)}%` : '--%';
+  if (mttrEl)   mttrEl.innerText   = mttr   != null ? `${mttr.toFixed(1)}h`   : '--h';
+  if (mtbfEl)   mtbfEl.innerText   = mtbf   != null ? `${mtbf.toFixed(1)}h`   : '--h';
+  if (pvupEl) {
+    const p = pPct != null ? pPct.toFixed(0) : '--';
+    const u = uPct != null ? uPct.toFixed(0) : '--';
+    pvupEl.innerText = `${p}% vs ${u}%`;
+  }
 }
 
 async function _updateHeader() {
   try {
-    const res = await fetch('/api/kpis');
-    if (!res.ok) throw new Error(await res.text());
-    const data = await res.json();
-    headerKpisCache = data;
-    renderHeader(data.overall);
+    const [weekRes, monthRes] = await Promise.all([
+      fetch('/api/kpis/by-asset?timeframe=lastWeek'),
+      fetch('/api/kpis/by-asset?timeframe=trailing30Days')
+    ]);
+
+    if (!weekRes.ok) throw new Error(await weekRes.text());
+    if (!monthRes.ok) throw new Error(await monthRes.text());
+
+    const [weekData, monthData] = await Promise.all([
+      weekRes.json(),
+      monthRes.json()
+    ]);
+
+    const lastWeekOverall   = computeTrueOverall(weekData);
+    const trailing30Overall = computeTrueOverall(monthData);
+
+    headerKpisCache = {
+      lastWeek: lastWeekOverall,
+      trailing30Days: trailing30Overall,
+      overall: { uptimePct: lastWeekOverall.uptimePct }
+    };
+
+    renderHeader({
+      lastWeek: lastWeekOverall,
+      trailing30Days: trailing30Overall
+    });
   } catch (err) {
     console.error('Header KPI fetch failed:', err);
   }


### PR DESCRIPTION
## Summary
- Compute header KPIs from by-asset endpoints so they use the same aggregation method as the asset table
- Display last week's uptime and planned/unplanned split alongside 30‑day MTTR/MTBF values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896258a53b48326a818118afcb32db7