### PR TITLE
Auto-exit burn-in mode at scheduled end

### DIFF
--- a/public/burnin.html
+++ b/public/burnin.html
@@ -32,6 +32,7 @@
 </head>
 <body>
   <div class="message">Burn-in Repair Mode Active<br>(Click anywhere to return to dashboard)</div>
+  <script src="burnin.js"></script>
   <script>
     document.addEventListener('click', () => {
       localStorage.setItem('burnInOverride', 'off');

--- a/public/burnin.js
+++ b/public/burnin.js
@@ -1,5 +1,19 @@
 (async function(){
-  await checkBurnIn();
+  const active = await checkBurnIn();
+  if (window.location.pathname === '/burnin.html') {
+    if (!active) {
+      localStorage.removeItem('burnInOverride');
+      window.location.href = '/index.html';
+    } else {
+      setInterval(async () => {
+        const stillBurn = await checkBurnIn();
+        if (!stillBurn) {
+          localStorage.removeItem('burnInOverride');
+          window.location.href = '/index.html';
+        }
+      }, 60000);
+    }
+  }
 })();
 
 async function checkBurnIn() {


### PR DESCRIPTION
## Summary
- Automatically exit burn-in page when scheduled window ends and redirect to dashboard
- Include burn-in scheduler script on burn-in page to enable schedule monitoring

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899eb651cac83269ba98e98a157ad92