### PR TITLE
Add totals row to KPI by asset table

### DIFF
--- a/public/js/kpi-by-asset.js
+++ b/public/js/kpi-by-asset.js
@@ -296,18 +296,24 @@ export async function loadAll() {
     const avgDowntime = downtimeVals.length
       ? downtimeVals.reduce((sum,v) => sum + v, 0) / downtimeVals.length
       : null;
+    const totalDowntime = downtimeVals.reduce((sum,v) => sum + v, 0);
     setText('avg-downtime', avgDowntime == null ? '—' : avgDowntime.toFixed(1));
+    setText('total-downtime', downtimeVals.length ? totalDowntime.toFixed(1) : '—');
     setText('avg-uptime',  avg('uptimePct').toFixed(1) + '%');
 
     const avgUnplannedCount = unplannedCounts.length
       ? unplannedCounts.reduce((s,v) => s + v, 0) / unplannedCounts.length
       : null;
+    const totalUnplannedCount = unplannedCounts.reduce((s,v) => s + v, 0);
     setText('avg-unplanned-count', avgUnplannedCount == null ? '—' : avgUnplannedCount.toFixed(1));
+    setText('total-unplanned-count', unplannedCounts.length ? totalUnplannedCount.toString() : '—');
 
     const avgFailureEvents = failureCounts.length
       ? failureCounts.reduce((s,v) => s + v, 0) / failureCounts.length
       : null;
+    const totalFailureEvents = failureCounts.reduce((s,v) => s + v, 0);
     setText('avg-failure-events', avgFailureEvents == null ? '—' : avgFailureEvents.toFixed(1));
+    setText('total-failure-events', failureCounts.length ? totalFailureEvents.toString() : '—');
 
     const avgMTTR = mttrValues.length
       ? mttrValues.reduce((s,v) => s + v, 0) / mttrValues.length
@@ -320,12 +326,11 @@ export async function loadAll() {
     setText('avg-mtbf', avgMTBF == null ? '—' : avgMTBF.toFixed(1));
 
     const totalPlanned = plannedCounts.reduce((s,v) => s + v, 0);
-    const totalUnplanned = unplannedCounts.reduce((s,v) => s + v, 0);
-    const plannedPctAvg = (totalPlanned + totalUnplanned) > 0
-      ? (totalPlanned / (totalPlanned + totalUnplanned)) * 100
+    const plannedPctAvg = (totalPlanned + totalUnplannedCount) > 0
+      ? (totalPlanned / (totalPlanned + totalUnplannedCount)) * 100
       : null;
-    const unplannedPctAvg = (totalPlanned + totalUnplanned) > 0
-      ? (totalUnplanned / (totalPlanned + totalUnplanned)) * 100
+    const unplannedPctAvg = (totalPlanned + totalUnplannedCount) > 0
+      ? (totalUnplannedCount / (totalPlanned + totalUnplannedCount)) * 100
       : null;
     setText('avg-planned', plannedPctAvg == null ? '—' : plannedPctAvg.toFixed(1) + '%');
     setText('avg-unplanned', unplannedPctAvg == null ? '—' : unplannedPctAvg.toFixed(1) + '%');

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -170,6 +170,26 @@
           <div id="avg-unplanned" class="kpi-value">--%</div>
         </td>
       </tr>
+      <tr class="kpi-total-row">
+        <td class="kpi-cell"></td>
+        <td class="kpi-cell">
+          <div class="kpi-title">Total Downtime Hrs</div>
+          <div id="total-downtime" class="kpi-value">--</div>
+        </td>
+        <td class="kpi-cell">
+          <div class="kpi-title">Total Unplanned Count</div>
+          <div id="total-unplanned-count" class="kpi-value">--</div>
+        </td>
+        <td class="kpi-cell">
+          <div class="kpi-title">Total Failure Events</div>
+          <div id="total-failure-events" class="kpi-value">--</div>
+        </td>
+        <td class="kpi-cell"></td>
+        <td class="kpi-cell"></td>
+        <td class="kpi-cell"></td>
+        <td class="kpi-cell"></td>
+        <td class="kpi-cell"></td>
+      </tr>
       </tfoot>
       </table>
       </div>


### PR DESCRIPTION
## Summary
- add "Totals" row to KPI-by-asset footer
- compute downtime, unplanned count, and failure event sums

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899f3292bb48326b3a7032915036b56