### PR TITLE
Display MTTR and MTBF side by side

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -169,6 +169,15 @@
         .top-border .header-kpi:last-of-type {
             margin-right: 160px;
         }
+        .header-mt {
+            display: flex;
+            gap: 40px;
+        }
+        .header-mt .header-metric {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
         #config-form { display:none; margin-top:20px; }
         label { display:block; margin-top:10px; }
     </style>
@@ -181,10 +190,14 @@
             <div id="uptime-value" class="kpi-value">--%</div>
         </div>
         <div class="header-mt">
-            <div class="kpi-title">MTTR (30d)</div>
-            <div id="mttr-value" class="kpi-value">--h</div>
-            <div class="kpi-title mtbf-title">MTBF (30d)</div>
-            <div id="mtbf-value" class="kpi-value">--h</div>
+            <div class="header-metric">
+                <div class="kpi-title">MTTR (30d)</div>
+                <div id="mttr-value" class="kpi-value">--h</div>
+            </div>
+            <div class="header-metric">
+                <div class="kpi-title mtbf-title">MTBF (30d)</div>
+                <div id="mtbf-value" class="kpi-value">--h</div>
+            </div>
         </div>
         <div id="clock"></div>
         <div class="header-kpi">

--- a/public/index.html
+++ b/public/index.html
@@ -186,6 +186,15 @@
         .top-border .header-kpi:last-of-type {
             margin-right: 160px;
         }
+        .header-mt {
+            display: flex;
+            gap: 40px;
+        }
+        .header-mt .header-metric {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
     </style>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" charset="utf-8">
 </head>
@@ -197,10 +206,14 @@
         <div id="uptime-value" class="kpi-value">--%</div>
       </div>
       <div class="header-mt">
-        <div class="kpi-title">MTTR (30d)</div>
-        <div id="mttr-value" class="kpi-value">--h</div>
-        <div class="kpi-title mtbf-title">MTBF (30d)</div>
-        <div id="mtbf-value" class="kpi-value">--h</div>
+        <div class="header-metric">
+          <div class="kpi-title">MTTR (30d)</div>
+          <div id="mttr-value" class="kpi-value">--h</div>
+        </div>
+        <div class="header-metric">
+          <div class="kpi-title mtbf-title">MTBF (30d)</div>
+          <div id="mtbf-value" class="kpi-value">--h</div>
+        </div>
       </div>
       <div id="clock">--:--:--</div>
       <div class="header-kpi">

--- a/public/kpi-by-asset-PRI-S-DataSrvr.html
+++ b/public/kpi-by-asset-PRI-S-DataSrvr.html
@@ -29,8 +29,11 @@
     .tabs { margin:10px 0; }
     .tabs a { text-decoration:none; color:#000; padding:8px 12px; border:1px solid #ccc; border-bottom:none; background:#eee; border-radius:4px 4px 0 0; margin-right:4px; }
     .tabs a.active { background:#fff; font-weight:bold; }
-    .top-border .header-kpi:first-of-type, .top-border .header-mt { margin-left:160px; }
+    .top-border .header-kpi:first-of-type,
+    .top-border .header-mt { margin-left:160px; }
     .top-border .header-kpi:last-of-type { margin-right:160px; }
+    .header-mt { display:flex; gap:40px; }
+    .header-mt .header-metric { display:flex; flex-direction:column; align-items:center; }
   </style>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
@@ -42,10 +45,14 @@
       <div id="uptime-value" class="kpi-value">--%</div>
     </div>
     <div class="header-mt">
-      <div class="kpi-title">MTTR (30d)</div>
-      <div id="mttr-value" class="kpi-value">--h</div>
-      <div class="kpi-title mtbf-title">MTBF (30d)</div>
-      <div id="mtbf-value" class="kpi-value">--h</div>
+      <div class="header-metric">
+        <div class="kpi-title">MTTR (30d)</div>
+        <div id="mttr-value" class="kpi-value">--h</div>
+      </div>
+      <div class="header-metric">
+        <div class="kpi-title mtbf-title">MTBF (30d)</div>
+        <div id="mtbf-value" class="kpi-value">--h</div>
+      </div>
     </div>
     <div id="clock">--:--:--</div>
     <div class="header-kpi">

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -29,8 +29,11 @@
     .tabs { margin:10px 0; }
     .tabs a { text-decoration:none; color:#000; padding:8px 12px; border:1px solid #ccc; border-bottom:none; background:#eee; border-radius:4px 4px 0 0; margin-right:4px; }
     .tabs a.active { background:#fff; font-weight:bold; }
-    .top-border .header-kpi:first-of-type, .top-border .header-mt { margin-left:160px; }
+    .top-border .header-kpi:first-of-type,
+    .top-border .header-mt { margin-left:160px; }
     .top-border .header-kpi:last-of-type { margin-right:160px; }
+    .header-mt { display:flex; gap:40px; }
+    .header-mt .header-metric { display:flex; flex-direction:column; align-items:center; }
     .true-overall-row { padding-bottom:4px; }
   </style>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -43,10 +46,14 @@
       <div id="uptime-value" class="kpi-value">--%</div>
     </div>
     <div class="header-mt">
-      <div class="kpi-title">MTTR (30d)</div>
-      <div id="mttr-value" class="kpi-value">--h</div>
-      <div class="kpi-title mtbf-title">MTBF (30d)</div>
-      <div id="mtbf-value" class="kpi-value">--h</div>
+      <div class="header-metric">
+        <div class="kpi-title">MTTR (30d)</div>
+        <div id="mttr-value" class="kpi-value">--h</div>
+      </div>
+      <div class="header-metric">
+        <div class="kpi-title mtbf-title">MTBF (30d)</div>
+        <div id="mtbf-value" class="kpi-value">--h</div>
+      </div>
     </div>
     <div id="clock">--:--:--</div>
     <div class="header-kpi">

--- a/public/pm.html
+++ b/public/pm.html
@@ -188,6 +188,15 @@
         .top-border .header-kpi:last-of-type {
             margin-right: 160px;
         }
+        .header-mt {
+            display: flex;
+            gap: 40px;
+        }
+        .header-mt .header-metric {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
     </style>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" charset="utf-8">
 </head>
@@ -199,10 +208,14 @@
             <div id="uptime-value" class="kpi-value">--%</div>
         </div>
         <div class="header-mt">
-            <div class="kpi-title">MTTR (30d)</div>
-            <div id="mttr-value" class="kpi-value">--h</div>
-            <div class="kpi-title mtbf-title">MTBF (30d)</div>
-            <div id="mtbf-value" class="kpi-value">--h</div>
+            <div class="header-metric">
+                <div class="kpi-title">MTTR (30d)</div>
+                <div id="mttr-value" class="kpi-value">--h</div>
+            </div>
+            <div class="header-metric">
+                <div class="kpi-title mtbf-title">MTBF (30d)</div>
+                <div id="mtbf-value" class="kpi-value">--h</div>
+            </div>
         </div>
         <div id="clock"></div>
         <div class="header-kpi">

--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -195,6 +195,15 @@
         .top-border .header-kpi:last-of-type {
             margin-right: 160px;
         }
+        .header-mt {
+            display: flex;
+            gap: 40px;
+        }
+        .header-mt .header-metric {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
         #status-table tr {
             height: 72px;
         }
@@ -213,10 +222,14 @@
         <div id="uptime-value" class="kpi-value">--%</div>
       </div>
       <div class="header-mt">
-        <div class="kpi-title">MTTR (30d)</div>
-        <div id="mttr-value" class="kpi-value">--h</div>
-        <div class="kpi-title mtbf-title">MTBF (30d)</div>
-        <div id="mtbf-value" class="kpi-value">--h</div>
+        <div class="header-metric">
+          <div class="kpi-title">MTTR (30d)</div>
+          <div id="mttr-value" class="kpi-value">--h</div>
+        </div>
+        <div class="header-metric">
+          <div class="kpi-title mtbf-title">MTBF (30d)</div>
+          <div id="mtbf-value" class="kpi-value">--h</div>
+        </div>
       </div>
       <div id="clock">--:--:--</div>
       <div class="header-kpi">


### PR DESCRIPTION
## Summary
- show MTTR and MTBF metrics side by side in header across all dashboard pages
- introduce flexbox layout to `.header-mt` and new `.header-metric` wrappers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899f4bb92e88326b5c344d8e5a5162a