### PR TITLE
Fix header uptime caching and apply 24x5 operational hours

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,9 @@ TEAMS_WEBHOOK_URL=
 
 # Optional debug flag
 DEBUG_KPIS=1
+
+# Expected machine run schedule
+# EXPECTED_RUN_DAYS accepts Mon-Fri, Sun-Sat, or comma-separated day abbreviations
+EXPECTED_RUN_DAYS=Mon-Fri
+# Hours per run day
+EXPECTED_HOURS_PER_DAY=24

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ The cache is controlled via environment variables:
 - `STATUS_REFRESH_ENDPOINT` – route for manually forcing a refresh (default `/api/cache/refresh`)
 - `API_BASE_URL` – base URL for Limble API requests (default `https://api.limblecmms.com:443`)
 
+### Operational hours
+Machines are assumed to run 24 hours per day, Monday through Friday. Override this schedule with:
+
+- `EXPECTED_RUN_DAYS` – comma list or ranges like `Mon-Fri` (default `Mon-Fri`)
+- `EXPECTED_HOURS_PER_DAY` – hours counted for each run day (default `24`)
+
 ### KPI time ranges
 KPI calculations default to the previous calendar week and previous calendar month. Override
 these ranges by setting any of the following environment variables to Unix timestamps:
@@ -113,7 +119,8 @@ The admin interface is available at `http://<LOCAL_IP>:<PORT>/admin`.
 | mtbfHrs | Last calendar month | `(workHours - downtimeHours) / count(unplanned tasks)` |
 | planned vs unplanned count | Last calendar week | Number of tasks of each type |
 
-* All assets are assumed to run 24/5.
+* All assets are assumed to run 24/5 unless configured via `EXPECTED_RUN_DAYS`/`EXPECTED_HOURS_PER_DAY`.
+* Uptime percentage is computed as `(operationalHours - downtimeHours) / operationalHours`.
 * Time ranges can be overridden via the `KPI_*` environment variables
   (see [KPI time ranges](#kpi-time-ranges)). When unset, the server uses the
   last calendar week and previous calendar month.

--- a/public/admin.html
+++ b/public/admin.html
@@ -431,10 +431,7 @@
     setInterval(updateClock, 1000);
     updateClock();
 </script>
-<script type="module">
-    import { initHeaderKPIs } from './js/header-kpis.js';
-    initHeaderKPIs();
-</script>
+<script type="module" src="js/header-kpis.js" defer></script>
 <script type="module" src="/js/admin.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -517,9 +517,6 @@
     setInterval(updateClock, 1000);
     updateClock();
 </script>
-<script type="module">
-  import { initHeaderKPIs } from './js/header-kpis.js';
-  initHeaderKPIs();
-</script>
+<script type="module" src="js/header-kpis.js" defer></script>
 </body>
 </html>

--- a/public/js/kpi-by-asset-PRI-S-DataSrvr.js
+++ b/public/js/kpi-by-asset-PRI-S-DataSrvr.js
@@ -1,5 +1,4 @@
 import { computeTrueOverall } from './compute-true-overall.js';
-import { headerKpisReady } from './header-kpis.js';
 
 let mappings;
 await fetch('/mappings.json')
@@ -179,7 +178,6 @@ function updateDateRangeLabel(tf, meta) {
 }
 
 export async function loadAll() {
-  await headerKpisReady();
   const tf = timeframeSelect?.value || 'lastMonth';
   const loadingEl = document.getElementById('loading');
   const errorEl   = document.getElementById('error-banner');

--- a/public/js/kpi-by-asset.js
+++ b/public/js/kpi-by-asset.js
@@ -1,5 +1,4 @@
 import { computeTrueOverall } from './compute-true-overall.js';
-import { headerKpisReady } from './header-kpis.js';
 
 let mappings;
 await fetch('/mappings.json')
@@ -202,7 +201,6 @@ function updateDateRangeLabel(tf, meta) {
 }
 
 export async function loadAll() {
-  await headerKpisReady();
   const tf = timeframeSelect?.value || 'lastMonth';
   const loadingEl = document.getElementById('loading');
   const errorEl   = document.getElementById('error-banner');

--- a/public/kpi-by-asset-PRI-S-DataSrvr.html
+++ b/public/kpi-by-asset-PRI-S-DataSrvr.html
@@ -186,10 +186,7 @@
       </div>
 
   </div>
-  <script type="module">
-    import { initHeaderKPIs } from './js/header-kpis.js';
-    initHeaderKPIs();
-  </script>
+  <script type="module" src="js/header-kpis.js" defer></script>
   <script type="module" src="/js/kpi-by-asset.js"></script>
   <script>
     const rotateBtn = document.getElementById('toggle-rotation');

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -207,10 +207,7 @@
       </div>
 
   </div>
-  <script type="module">
-    import { initHeaderKPIs } from './js/header-kpis.js';
-    initHeaderKPIs();
-  </script>
+  <script type="module" src="js/header-kpis.js" defer></script>
   <script type="module" src="/js/kpi-by-asset.js"></script>
   <script>
     const rotateBtn = document.getElementById('toggle-rotation');

--- a/public/pm.html
+++ b/public/pm.html
@@ -519,9 +519,6 @@
     setInterval(updateClock, 1000);
     updateClock();
 </script>
-<script type="module">
-  import { initHeaderKPIs } from './js/header-kpis.js';
-  initHeaderKPIs();
-</script>
+<script type="module" src="js/header-kpis.js" defer></script>
 </body>
 </html>

--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -601,9 +601,6 @@
     setInterval(updateClock, 1000);
     updateClock();
 </script>
-<script type="module">
-  import { initHeaderKPIs } from './js/header-kpis.js';
-  initHeaderKPIs();
-</script>
+<script type="module" src="js/header-kpis.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- cache-bust header KPI fetch and retry on HTTP 304s
- add configurable 24x5 expectedOperationalHours backend utility
- rely on operationalHours for uptime/MTBF calculations across client helpers
- document EXPECTED_RUN_DAYS and EXPECTED_HOURS_PER_DAY env vars

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a19dc62948326b0429e4268d75dc4