### PR TITLE
Switch uptime KPI to downtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ The admin interface is available at `http://<LOCAL_IP>:<PORT>/admin`.
 
 | KPI | Timeframe | Description |
 |-----|-----------|-------------|
-| uptimePct | Last calendar week | `((workHours - downtimeHours) / workHours) * 100` |
+| downtimePct | Last calendar week | `(downtimeHours / operationalHours) * 100` |
 | downtimeHrs | Last calendar week | Sum of all downtime labor entries in hours |
 | mttrHrs | Last calendar month | `Σ downtimeHours / count(unplanned tasks)` |
 | mtbfHrs | Last calendar month | `(workHours - downtimeHours) / count(unplanned tasks)` |
 | planned vs unplanned count | Last calendar week | Number of tasks of each type |
 
 * All assets are assumed to run 24/5 unless configured via `EXPECTED_RUN_DAYS`/`EXPECTED_HOURS_PER_DAY`.
-* Uptime percentage is computed as `(operationalHours - downtimeHours) / operationalHours`.
+* Downtime percentage is computed as `(downtimeHours / operationalHours) * 100`.
 * Time ranges can be overridden via the `KPI_*` environment variables
   (see [KPI time ranges](#kpi-time-ranges)). When unset, the server uses the
   last calendar week and previous calendar month.

--- a/config/kpi-theme.json
+++ b/config/kpi-theme.json
@@ -18,9 +18,9 @@
     }
   },
   "thresholds": {
-    "uptimePct": {
-      "goodMin": 85,
-      "warnMin": 75
+    "downtimePct": {
+      "goodMax": 15,
+      "warnMax": 25
     },
     "plannedPct": {
       "goodMin": 70,

--- a/public/admin.html
+++ b/public/admin.html
@@ -188,8 +188,8 @@
     <div class="top-border">
         <img src="img/pri-logo.png" alt="PRI Logo" class="logo">
         <div class="header-kpi">
-            <div class="kpi-title">Maintenance Uptime (Last Week)</div>
-            <div id="uptime-value" class="kpi-value">--%</div>
+            <div class="kpi-title">Maintenance Downtime (Last Week)</div>
+            <div id="downtime-value" class="kpi-value">--%</div>
         </div>
         <div class="header-mt">
             <div class="header-metric">
@@ -270,8 +270,8 @@
         <fieldset>
             <legend>Thresholds</legend>
             <div>
-                <label>Uptime % goodMin <input type="number" id="thr-uptimePct-goodMin" class="num-input"></label><span class="input-error"></span>
-                <label>Uptime % warnMin <input type="number" id="thr-uptimePct-warnMin" class="num-input"></label><span class="input-error"></span>
+                <label>Downtime % goodMax <input type="number" id="thr-downtimePct-goodMax" class="num-input"></label><span class="input-error"></span>
+                <label>Downtime % warnMax <input type="number" id="thr-downtimePct-warnMax" class="num-input"></label><span class="input-error"></span>
                 <label>Planned % goodMin <input type="number" id="thr-plannedPct-goodMin" class="num-input"></label><span class="input-error"></span>
                 <label>Planned % warnMin <input type="number" id="thr-plannedPct-warnMin" class="num-input"></label><span class="input-error"></span>
                 <label>Unplanned % goodMax <input type="number" id="thr-unplannedPct-goodMax" class="num-input"></label><span class="input-error"></span>

--- a/public/index.html
+++ b/public/index.html
@@ -204,8 +204,8 @@
     <div class="top-border">
       <img src="img/pri-logo.png" alt="PRI Logo" class="logo" />
       <div class="header-kpi">
-        <div class="kpi-title">Maintenance Uptime (Last Week)</div>
-        <div id="uptime-value" class="kpi-value">--%</div>
+        <div class="kpi-title">Maintenance Downtime (Last Week)</div>
+        <div id="downtime-value" class="kpi-value">--%</div>
       </div>
 	 <div class="header-mt">
         <div class="header-metric">

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -6,7 +6,7 @@ const DEFAULT_THEME = {
     neutral: { bg: '#374151', fg: '#FFFFFF' }
   },
   thresholds: {
-    uptimePct:   { goodMin: 98.0, warnMin: 95.0 },
+    downtimePct: { goodMax: 2.0, warnMax: 5.0 },
     plannedPct:  { goodMin: 70.0, warnMin: 50.0 },
     unplannedPct:{ goodMax: 30.0, warnMax: 50.0 },
     mttrHours:   { goodMax: 1.5,  warnMax: 3.0 },
@@ -19,7 +19,7 @@ const hexInputs = [
   'color-bad-bg','color-bad-fg','color-neutral-bg','color-neutral-fg'
 ];
 const numInputs = [
-  'thr-uptimePct-goodMin','thr-uptimePct-warnMin',
+  'thr-downtimePct-goodMax','thr-downtimePct-warnMax',
   'thr-plannedPct-goodMin','thr-plannedPct-warnMin',
   'thr-unplannedPct-goodMax','thr-unplannedPct-warnMax',
   'thr-mttrHours-goodMax','thr-mttrHours-warnMax',
@@ -37,8 +37,8 @@ function populate(theme) {
   $('color-bad-fg').value = theme.colors.bad.fg;
   $('color-neutral-bg').value = theme.colors.neutral.bg;
   $('color-neutral-fg').value = theme.colors.neutral.fg;
-  $('thr-uptimePct-goodMin').value = theme.thresholds.uptimePct.goodMin;
-  $('thr-uptimePct-warnMin').value = theme.thresholds.uptimePct.warnMin;
+  $('thr-downtimePct-goodMax').value = theme.thresholds.downtimePct.goodMax;
+  $('thr-downtimePct-warnMax').value = theme.thresholds.downtimePct.warnMax;
   $('thr-plannedPct-goodMin').value = theme.thresholds.plannedPct.goodMin;
   $('thr-plannedPct-warnMin').value = theme.thresholds.plannedPct.warnMin;
   $('thr-unplannedPct-goodMax').value = theme.thresholds.unplannedPct.goodMax;
@@ -58,7 +58,7 @@ function collect() {
       neutral:{ bg: $('color-neutral-bg').value.trim(), fg: $('color-neutral-fg').value.trim() }
     },
     thresholds: {
-      uptimePct:   { goodMin: parseFloat($('thr-uptimePct-goodMin').value),   warnMin: parseFloat($('thr-uptimePct-warnMin').value) },
+      downtimePct: { goodMax: parseFloat($('thr-downtimePct-goodMax').value), warnMax: parseFloat($('thr-downtimePct-warnMax').value) },
       plannedPct:  { goodMin: parseFloat($('thr-plannedPct-goodMin').value),  warnMin: parseFloat($('thr-plannedPct-warnMin').value) },
       unplannedPct:{ goodMax: parseFloat($('thr-unplannedPct-goodMax').value), warnMax: parseFloat($('thr-unplannedPct-warnMax').value) },
       mttrHours:   { goodMax: parseFloat($('thr-mttrHours-goodMax').value),  warnMax: parseFloat($('thr-mttrHours-warnMax').value) },

--- a/public/js/compute-true-overall.js
+++ b/public/js/compute-true-overall.js
@@ -20,9 +20,9 @@ function getFailureEventCount(row) {
 /**
  * Compute true overall KPIs for the by-asset payload.
  * Prefers additive totals from payload.totals, falls back to summing per-asset fields.
- * For uptimePct, if we cannot compute due to missing hours the result is null.
+ * For downtimePct, if we cannot compute due to missing hours the result is null.
  * @param {object} data - payload from /api/kpis/by-asset
- * @returns {{uptimePct: number|null, mttrHrs: number|null, mtbfHrs: number|null, plannedPct: number|null, unplannedPct: number|null}}
+ * @returns {{downtimePct: number|null, mttrHrs: number|null, mtbfHrs: number|null, plannedPct: number|null, unplannedPct: number|null}}
  */
 export function computeTrueOverall(data = {}) {
   const rows = data.rows || data.byAsset || Object.values(data.assets || {});
@@ -43,9 +43,9 @@ export function computeTrueOverall(data = {}) {
 
   const totalWo = planned + unplanned;
 
-  let uptimePct = null;
+  let downtimePct = null;
   if (operationalHours > 0) {
-    uptimePct = (1 - (downtime / operationalHours)) * 100;
+    downtimePct = (downtime / operationalHours) * 100;
   }
 
   const mttr = failures > 0 ? unplannedDowntime / failures : null;
@@ -53,5 +53,5 @@ export function computeTrueOverall(data = {}) {
   const plannedPct = totalWo > 0 ? (planned / totalWo) * 100 : null;
   const unplannedPct = totalWo > 0 ? (unplanned / totalWo) * 100 : null;
 
-  return { uptimePct, mttrHrs: mttr, mtbfHrs: mtbf, plannedPct, unplannedPct };
+  return { downtimePct, mttrHrs: mttr, mtbfHrs: mtbf, plannedPct, unplannedPct };
 }

--- a/public/js/header-kpis-PRI-S-DataSrvr.js
+++ b/public/js/header-kpis-PRI-S-DataSrvr.js
@@ -29,20 +29,20 @@ export async function loadHeaderKpis() {
     const data = await fetchJsonNo304('/api/kpis/by-asset?timeframe=lastWeek');
 
     // Prefer server aggregate; fallback to compute if missing
-    let uptime = data?.totals?.uptimePct;
-    if (uptime == null && data?.assets) {
+    let downtime = data?.totals?.downtimePct;
+    if (downtime == null && data?.assets) {
       const sums = Object.values(data.assets).reduce((a, x) => {
         a.op += Number(x.operationalHours || 0);
         a.dt += Number(x.downtimeHrs || 0);
         return a;
       }, { op: 0, dt: 0 });
-      uptime = sums.op ? (100 * (sums.op - sums.dt) / sums.op) : null;
+      downtime = sums.op ? (100 * sums.dt / sums.op) : null;
     }
 
-    setText('uptime-value', fmtPct(uptime));
+    setText('downtime-value', fmtPct(downtime));
   } catch (e) {
     console.error('Header KPI load error', e);
-    setText('uptime-value', '--%');
+    setText('downtime-value', '--%');
   }
 }
 

--- a/public/js/header-kpis.js
+++ b/public/js/header-kpis.js
@@ -64,9 +64,9 @@ export async function initHeaderKPIs() {
     const weekOverall  = computeTrueOverall(weekData)  || {};
     const monthOverall = computeTrueOverall(monthData) || {};
 
-    // Uptime (last week)
-    const uptime = weekOverall.uptimePct ?? weekData?.totals?.uptimePct ?? null;
-    setText('uptime-value', fmtPct(uptime));
+    // Downtime (last week)
+    const downtime = weekOverall.downtimePct ?? weekData?.totals?.downtimePct ?? null;
+    setText('downtime-value', fmtPct(downtime));
 
     // MTTR / MTBF (last 30 days)
     const mttr = monthOverall.mttrHrs ?? monthData?.totals?.mttrHrs ?? null;
@@ -85,7 +85,7 @@ export async function initHeaderKPIs() {
 
   } catch (err) {
     console.error('Header KPI load error:', err);
-    setText('uptime-value', '--%');
+    setText('downtime-value', '--%');
     setText('mttr-value', '--h');
     setText('mtbf-value', '--h');
     setText('planned-vs-unplanned', '--% vs --%');

--- a/public/js/kpi-by-asset-PRI-S-DataSrvr.js
+++ b/public/js/kpi-by-asset-PRI-S-DataSrvr.js
@@ -15,7 +15,7 @@ const DEFAULT_THEME = {
     neutral: { bg: '#374151', fg: '#FFFFFF' }
   },
   thresholds: {
-    uptimePct:   { goodMin: 98.0, warnMin: 95.0 },
+    downtimePct: { goodMax: 2.0, warnMax: 5.0 },
     plannedPct:  { goodMin: 70.0, warnMin: 50.0 },
     unplannedPct:{ goodMax: 30.0, warnMax: 50.0 },
     mttrHours:   { goodMax: 1.5,  warnMax: 3.0 },
@@ -45,16 +45,18 @@ function setText(id, text) {
 function classifyByThreshold(metricKey, value, theme) {
   if (value == null || isNaN(value)) return 'neutral';
   const t = theme?.thresholds?.[metricKey] || {};
-  if (metricKey === 'uptimePct' || metricKey === 'plannedPct' || metricKey === 'mtbfHours') {
-    const { goodMin, warnMin } = t;
-    if (typeof goodMin === 'number' && value >= goodMin) return 'good';
-    if (typeof warnMin === 'number' && value >= warnMin) return 'warn';
+  if (typeof t.goodMax === 'number' || typeof t.warnMax === 'number') {
+    const goodMax = typeof t.goodMax === 'number' ? t.goodMax : Infinity;
+    const warnMax = typeof t.warnMax === 'number' ? t.warnMax : Infinity;
+    if (value <= goodMax) return 'good';
+    if (value <= warnMax) return 'warn';
     return 'bad';
   }
-  if (metricKey === 'unplannedPct' || metricKey === 'mttrHours') {
-    const { goodMax, warnMax } = t;
-    if (typeof goodMax === 'number' && value <= goodMax) return 'good';
-    if (typeof warnMax === 'number' && value <= warnMax) return 'warn';
+  if (typeof t.goodMin === 'number' || typeof t.warnMin === 'number') {
+    const goodMin = typeof t.goodMin === 'number' ? t.goodMin : -Infinity;
+    const warnMin = typeof t.warnMin === 'number' ? t.warnMin : -Infinity;
+    if (value >= goodMin) return 'good';
+    if (value >= warnMin) return 'warn';
     return 'bad';
   }
   return 'neutral';
@@ -244,7 +246,7 @@ export async function loadAll() {
         ${downtimeTd}
         ${unplannedTd}
         ${failureTd}
-        <td>${a.uptimePct.toFixed(1)}</td>
+        <td>${a.downtimePct.toFixed(1)}</td>
         ${mttrTd}
         ${mtbfTd}
         <td>${plannedPct == null ? '—' : plannedPct.toFixed(1)}</td>
@@ -274,7 +276,7 @@ export async function loadAll() {
       ? downtimeVals.reduce((sum,v) => sum + v, 0) / downtimeVals.length
       : null;
     setText('avg-downtime', avgDowntime == null ? '—' : avgDowntime.toFixed(1));
-    setText('avg-uptime',  avg('uptimePct').toFixed(1) + '%');
+    setText('avg-downtime-pct', avg('downtimePct').toFixed(1) + '%');
 
     const avgUnplannedCount = unplannedCounts.length
       ? unplannedCounts.reduce((s,v) => s + v, 0) / unplannedCounts.length
@@ -350,7 +352,7 @@ loadAll();
 
 function renderTrueOverall(kpis) {
   const specs = [
-    { id: 'tile-uptime',     key: 'uptimePct',    val: kpis.uptimePct,   suffix: '%' },
+    { id: 'tile-downtime',   key: 'downtimePct',  val: kpis.downtimePct, suffix: '%' },
     { id: 'tile-mttr',       key: 'mttrHours',    val: kpis.mttrHrs,     suffix: 'h' },
     { id: 'tile-mtbf',       key: 'mtbfHours',    val: kpis.mtbfHrs,     suffix: 'h' },
     { id: 'tile-planned',    key: 'plannedPct',   val: kpis.plannedPct,  suffix: '%' },

--- a/public/kpi-by-asset-PRI-S-DataSrvr.html
+++ b/public/kpi-by-asset-PRI-S-DataSrvr.html
@@ -46,8 +46,8 @@
   <div class="top-border">
     <img src="img/pri-logo.png" alt="PRI Logo" class="logo" />
     <div class="header-kpi">
-      <div class="kpi-title">Maintenance Uptime (Last Week)</div>
-      <div id="uptime-value" class="kpi-value">--%</div>
+      <div class="kpi-title">Maintenance Downtime (Last Week)</div>
+      <div id="downtime-value" class="kpi-value">--%</div>
     </div>
     <div class="header-mt">
       <div class="header-metric">
@@ -82,9 +82,9 @@
     </div>
     <h2>All Assets — True Overall</h2>
     <div id="true-overall-row" class="true-overall-row">
-      <div class="kpi-tile" id="tile-uptime">
-        <div class="label">Uptime %</div>
-        <div class="value" data-testid="true-overall-uptime">--%</div>
+      <div class="kpi-tile" id="tile-downtime">
+        <div class="label">Downtime %</div>
+        <div class="value" data-testid="true-overall-downtime">--%</div>
       </div>
       <div class="kpi-tile" id="tile-mttr">
         <div class="label">MTTR (h)</div>
@@ -134,7 +134,7 @@
           <th class="col-downtime" data-testid="col-downtime-hrs">Downtime Hrs</th>
           <th class="col-int" data-testid="col-unplanned-count">Unplanned Count</th>
           <th class="col-int" data-testid="col-failure-events">Failure Events</th>
-          <th>Uptime %</th>
+          <th>Downtime %</th>
           <th>MTTR</th>
           <th>MTBF</th>
           <th>Planned %</th>
@@ -161,8 +161,8 @@
           <div id="avg-failure-events" class="kpi-value">--</div>
         </td>
         <td class="kpi-cell">
-          <div class="kpi-title">Avg Uptime %</div>
-          <div id="avg-uptime" class="kpi-value">--%</div>
+          <div class="kpi-title">Avg Downtime %</div>
+          <div id="avg-downtime-pct" class="kpi-value">--%</div>
         </td>
         <td class="kpi-cell">
           <div class="kpi-title">Avg MTTR (h)</div>

--- a/public/kpi-by-asset.html
+++ b/public/kpi-by-asset.html
@@ -47,8 +47,8 @@
   <div class="top-border">
     <img src="img/pri-logo.png" alt="PRI Logo" class="logo" />
     <div class="header-kpi">
-      <div class="kpi-title">Maintenance Uptime (Last Week)</div>
-      <div id="uptime-value" class="kpi-value">--%</div>
+      <div class="kpi-title">Maintenance Downtime (Last Week)</div>
+      <div id="downtime-value" class="kpi-value">--%</div>
     </div>
     <div class="header-mt">
       <div class="header-metric">
@@ -83,9 +83,9 @@
     </div>
     <h2>All Assets — True Overall</h2>
     <div id="true-overall-row" class="true-overall-row">
-      <div class="kpi-tile" id="tile-uptime">
-        <div class="label">Uptime %</div>
-        <div class="value" data-testid="true-overall-uptime">--%</div>
+      <div class="kpi-tile" id="tile-downtime">
+        <div class="label">Downtime %</div>
+        <div class="value" data-testid="true-overall-downtime">--%</div>
       </div>
       <div class="kpi-tile" id="tile-mttr">
         <div class="label">MTTR (h)</div>
@@ -135,7 +135,7 @@
           <th class="col-downtime" data-testid="col-downtime-hrs">Downtime Hrs</th>
           <th class="col-int" data-testid="col-unplanned-count">Unplanned Count</th>
           <th class="col-int" data-testid="col-failure-events">Failure Events</th>
-          <th>Uptime %</th>
+          <th>Downtime %</th>
           <th>MTTR</th>
           <th>MTBF</th>
           <th>Planned %</th>
@@ -162,8 +162,8 @@
           <div id="avg-failure-events" class="kpi-value">--</div>
         </td>
         <td class="kpi-cell">
-          <div class="kpi-title">Avg Uptime %</div>
-          <div id="avg-uptime" class="kpi-value">--%</div>
+          <div class="kpi-title">Avg Downtime %</div>
+          <div id="avg-downtime-pct" class="kpi-value">--%</div>
         </td>
         <td class="kpi-cell">
           <div class="kpi-title">Avg MTTR (h)</div>

--- a/public/pm.html
+++ b/public/pm.html
@@ -206,8 +206,8 @@
     <div class="top-border">
         <img src="img/pri-logo.png" alt="PRI Logo" class="logo">
         <div class="header-kpi">
-            <div class="kpi-title">Maintenance Uptime (Last Week)</div>
-            <div id="uptime-value" class="kpi-value">--%</div>
+            <div class="kpi-title">Maintenance Downtime (Last Week)</div>
+            <div id="downtime-value" class="kpi-value">--%</div>
         </div>
         <div class="header-mt">
             <div class="header-metric">

--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -220,8 +220,8 @@
     <div class="top-border">
       <img src="img/pri-logo.png" alt="PRI Logo" class="logo" />
       <div class="header-kpi">
-        <div class="kpi-title">Maintenance Uptime (Last Week)</div>
-        <div id="uptime-value" class="kpi-value">--%</div>
+        <div class="kpi-title">Maintenance Downtime (Last Week)</div>
+        <div id="downtime-value" class="kpi-value">--%</div>
       </div>
       <div class="header-mt">
         <div class="header-metric">

--- a/server-PRI-S-DataSrvr.js
+++ b/server-PRI-S-DataSrvr.js
@@ -115,7 +115,7 @@ const DEFAULT_THEME = {
     neutral:{ bg: '#374151', fg: '#FFFFFF' }
   },
   thresholds: {
-    uptimePct:   { goodMin: 98.0, warnMin: 95.0 },
+    downtimePct: { goodMax: 2.0, warnMax: 5.0 },
     plannedPct:  { goodMin: 70.0, warnMin: 50.0 },
     unplannedPct:{ goodMax: 30.0, warnMax: 50.0 },
     mttrHours:   { goodMax: 1.5,  warnMax: 3.0 },
@@ -313,8 +313,8 @@ async function loadOverallKpis() {
   // ─── END 30-DAY LABOR SECTION ──────────────────────────────────────────
   
   // Final KPI calculations
-  const uptimePct = totals.operationalHours
-    ? ((totals.operationalHours - totals.downtimeHours) / totals.operationalHours) * 100
+  const downtimePct = totals.operationalHours
+    ? Math.max(0, Math.min(100, (totals.downtimeHours / totals.operationalHours) * 100))
     : 0;
   const mttrHrs = totals.unplannedWO
     ? (totals.downtimeMinutes / 60) / totals.unplannedWO
@@ -325,7 +325,7 @@ async function loadOverallKpis() {
   const mtbfHrs     = intervals.length ? _.mean(intervals) : 0;
 
   return {
-    uptimePct: +uptimePct.toFixed(1),
+    downtimePct: +downtimePct.toFixed(1),
     downtimeHrs: +totals.downtimeHours.toFixed(1),
     mttrHrs: +mttrHrs.toFixed(1),
     mtbfHrs: +mtbfHrs.toFixed(1),
@@ -350,7 +350,7 @@ async function loadByAssetKpis({ start, end }) {
   };
 
   const result = { assets: {}, totals: {
-    uptimePct: 0,
+    downtimePct: 0,
     downtimeHrs: 0,
     mttrHrs: 0,
     mtbfHrs: 0,
@@ -423,14 +423,14 @@ async function loadByAssetKpis({ start, end }) {
     const downtimeHours = downtimeMinutesAll / 60;
     const downtimeHoursUnplanned = downtimeMinutesUnplanned / 60;
     const uptimeHours = Math.max(0, opHours - downtimeHours);
-    const uptime = opHours > 0
-      ? Math.max(0, Math.min(100, (uptimeHours / opHours) * 100))
+    const downtimePct = opHours > 0
+      ? Math.max(0, Math.min(100, (downtimeHours / opHours) * 100))
       : 0;
 
     // save per-asset
     result.assets[id] = {
       name,
-      uptimePct: +uptime.toFixed(1),
+      downtimePct: +downtimePct.toFixed(1),
       downtimeHrs: +downtimeHours.toFixed(1),
       mttrHrs: +mttr.toFixed(1),
       mtbfHrs: +mtbf.toFixed(1),
@@ -452,8 +452,8 @@ async function loadByAssetKpis({ start, end }) {
   }
 
   // totals
-  result.totals.uptimePct   = totalOperationalHours
-    ? +((totalUptimeHours / totalOperationalHours) * 100).toFixed(1)
+  result.totals.downtimePct   = totalOperationalHours
+    ? +((totalDowntimeHours / totalOperationalHours) * 100).toFixed(1)
     : 0;
   result.totals.downtimeHrs = +totalDowntimeHours.toFixed(1);
   result.totals.mttrHrs     = totalUnplannedWO
@@ -569,7 +569,7 @@ app.put('/api/settings/kpi-theme', (req, res) => {
   }
 
   const metricDefs = {
-    uptimePct: ['goodMin', 'warnMin'],
+    downtimePct: ['goodMax', 'warnMax'],
     plannedPct: ['goodMin', 'warnMin'],
     unplannedPct: ['goodMax', 'warnMax'],
     mttrHours: ['goodMax', 'warnMax'],

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -10,7 +10,7 @@ const serverModule = await import('../server.js');
 const app = serverModule.default;
 
 const dummyOverall = {
-  uptimePct: 98,
+  downtimePct: 2,
   downtimeHrs: 2,
   mttrHrs: 1,
   mtbfHrs: 100,
@@ -22,7 +22,7 @@ const dummyByAsset = {
   assets: {
     '2399': {
       name: 'Asset1',
-      uptimePct: 97,
+      downtimePct: 3,
       downtimeHrs: 3,
       mttrHrs: 2,
       mtbfHrs: 50,
@@ -31,7 +31,7 @@ const dummyByAsset = {
     }
   },
   totals: {
-    uptimePct: 97,
+    downtimePct: 3,
     downtimeHrs: 3,
     mttrHrs: 2,
     mtbfHrs: 50,


### PR DESCRIPTION
## Summary
- replace uptime percentage with downtime percentage in KPI theme and server calculations
- show maintenance downtime in header and asset KPI pages with updated classification thresholds
- document downtimePct formula and adjust tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bc415fcac832681a0fa358450724e