### PR TITLE
Harden KPI and status scripts against null data

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -195,12 +195,13 @@ async function runJob(name) {
   });
   document.getElementById('run-status').textContent = res.ok ? `Ran ${name}` : `Failed ${name}`;
 }
-document.getElementById('run-header')?.addEventListener('click', ()=>runJob('header_kpis'));
-document.getElementById('run-byasset')?.addEventListener('click', ()=>runJob('by_asset_kpis'));
-document.getElementById('run-wo-index')?.addEventListener('click', ()=>runJob('work_orders_index'));
-document.getElementById('run-wo-pm')?.addEventListener('click', ()=>runJob('work_orders_pm'));
-document.getElementById('run-wo-status')?.addEventListener('click', ()=>runJob('work_orders_status'));
-document.getElementById('run-all')?.addEventListener('click', async ()=>{
+(document.getElementById('run-header')   || {}).onclick = ()=>runJob('header_kpis');
+(document.getElementById('run-byasset')  || {}).onclick = ()=>runJob('by_asset_kpis');
+(document.getElementById('run-wo-index') || {}).onclick = ()=>runJob('work_orders_index');
+(document.getElementById('run-wo-pm')    || {}).onclick = ()=>runJob('work_orders_pm');
+(document.getElementById('run-wo-status')|| {}).onclick = ()=>runJob('work_orders_status');
+(document.getElementById('run-all')      || {}).onclick = async ()=>{
   const res = await fetch('/api/admin/refresh-all', { method: 'POST' });
-  document.getElementById('run-status').textContent = res.ok ? 'Refreshed all' : 'Refresh all failed';
-});
+  const el = document.getElementById('run-status');
+  if (el) el.textContent = res.ok ? 'Refreshed all' : 'Refresh all failed';
+};

--- a/public/prodstatus.html
+++ b/public/prodstatus.html
@@ -526,10 +526,17 @@
 
       async function loadStatus() {
         // Primary: cached endpoint; alias /api/status also exists for back-compat
-        const res = await fetch('/api/workorders/prodstatus');
-        const { status, nextRefresh } = await res.json();
-        renderStatus(status);
-        scheduleRefresh(Math.max(0, nextRefresh - Date.now()));
+        const res = await fetch('/api/workorders/prodstatus?t=' + Date.now(), { cache: 'no-store' });
+        const data = await res.json();
+        // rows may be in data.rows or (legacy) data.tiles; normalize to an array
+        const rows = Array.isArray(data?.rows) ? data.rows
+                    : (Array.isArray(data?.tiles) ? data.tiles : []);
+        if (!rows.length) {
+          console.warn('[prodstatus] no rows to render yet');
+          return;
+        }
+        renderStatus(rows, data.lastRefreshUtc);
+        if (data.nextRefresh) scheduleRefresh(Math.max(0, data.nextRefresh - Date.now()));
       }
 
       async function refreshAll() {
@@ -537,15 +544,24 @@
         await loadStatus();
       }
 
-      function renderStatus(status) {
+      function renderStatus(rows, lastRefreshUtc) {
+        // Defensive helpers
+        const asArr  = (x) => Array.isArray(x) ? x : [];
+        const sfind  = (x, fn) => asArr(x).find(fn);
+        const sfor   = (x, fn) => asArr(x).forEach(fn);
+
         const tbody = document.getElementById('status-data');
         tbody.innerHTML = '';
-        (mappings.productionAssets || []).forEach(item => {
-          const entry = status.find(s => s.assetID === item.id) || {};
+        if (lastRefreshUtc) {
+          const lrEl = document.getElementById('last-refresh-status');
+          if (lrEl) lrEl.textContent = `· Last refresh: ${new Date(lastRefreshUtc).toLocaleString()}`;
+        }
+        sfor(mappings.productionAssets, item => {
+          const entry = sfind(rows, s => s.assetID === item.id) || {};
           const tr = document.createElement('tr');
           const colorMap = mappings.statusColorMapping || {};
           const textMap  = mappings.statusTextMapping || {};
-          const statusId = Object.keys(textMap).find(k => textMap[k] === entry.status);
+          const statusId = sfind(Object.keys(textMap), k => textMap[k] === entry.status);
           const bg = colorMap[statusId] || colorMap[entry.status] || '#fff';
           tr.style.backgroundColor = bg;
           const bgLower = bg.toLowerCase();


### PR DESCRIPTION
## Summary
- Guard KPI-by-asset loader against missing rows and duplicate consts; derive assets map defensively
- Normalize production status data, avoid `.find` on undefined collections, and skip rendering when no rows
- Prevent null element errors on Admin refresh buttons

## Testing
- `npm test` *(fails: Property `fetchAndCache` does not exist / config.server required)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a516d05a688326b0d56bd87acb64bb