### PR TITLE
feat: harden mapping loader and surface job errors

### DIFF
--- a/docs/CACHING_AND_SCHEDULES.md
+++ b/docs/CACHING_AND_SCHEDULES.md
@@ -8,3 +8,13 @@
 - Each endpoint returns `lastRefreshUtc` for UI display.
 - NodeCache removed.
 
+### Asset mappings source
+- Server jobs load `mappings.json` from:
+  1) `MAPPINGS_PATH` (env var), or
+  2) repo root `./mappings.json`, or
+  3) `./public/mappings.json`
+- Expected shape: 
+  ```json
+  { "assets": [ { "assetID": 101, "name": "Extrusion Line E1" }, ... ] }
+  ```
+

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -189,13 +189,26 @@ loadSchedules();
 
 // ---- Run Now wiring (guarded) ----
 async function runJob(name) {
-  const res = await fetch('/api/admin/run', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ job: name })
-  });
+  let msg = '';
+  try {
+    const res = await fetch('/api/admin/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ job: name })
+    });
+    if (res.ok) {
+      msg = `Ran ${name}`;
+    } else {
+      // Try to parse JSON error, else show raw text
+      let body = '';
+      try { body = await res.text(); } catch {}
+      msg = `Failed ${name}${body ? `: ${body}` : ''}`;
+    }
+  } catch (e) {
+    msg = `Failed ${name}: ${String(e)}`;
+  }
   const el = document.getElementById('run-status');
-  if (el) el.textContent = res.ok ? `Ran ${name}` : `Failed ${name}`;
+  if (el) el.textContent = msg;
 }
 (document.getElementById('run-header')   || {}).onclick = ()=>runJob('header_kpis');
 (document.getElementById('run-byasset')  || {}).onclick = ()=>runJob('by_asset_kpis');


### PR DESCRIPTION
## Summary
- add robust mappings.json loader with fallback paths and warnings
- show server error response text in Admin "Run Now" panel
- document mappings.json lookup order and expected shape

## Testing
- `npm test` *(fails: Property `fetchAndCache` does not exist; requires app config)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a51dac07348326baded9becef5a439