### PR TITLE
feat: expose job run results

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -197,7 +197,16 @@ async function runJob(name) {
       body: JSON.stringify({ job: name })
     });
     if (res.ok) {
-      msg = `Ran ${name}`;
+      let body = '';
+      try { body = await res.text(); } catch {}
+      try {
+        const j = JSON.parse(body || '{}');
+        const r = j.result || {};
+        const extra = Object.keys(r).length ? ` (result: ${JSON.stringify(r)})` : '';
+        msg = `Ran ${name}${extra}`;
+      } catch {
+        msg = `Ran ${name}`;
+      }
     } else {
       // Try to parse JSON error, else show raw text
       let body = '';

--- a/server.js
+++ b/server.js
@@ -770,28 +770,29 @@ app.post('/api/admin/run', async (req, res) => {
     const { job } = req.body || {};
     if (!job) return res.status(400).json({ error: 'missing job' });
     const pool = await poolPromise;
+    let result;
     switch (job) {
       case 'header_kpis':
-        await refreshHeaderKpis(pool);
+        result = await refreshHeaderKpis(pool);
         break;
       case 'by_asset_kpis':
-        await refreshByAssetKpis(pool);
+        result = await refreshByAssetKpis(pool);
         break;
       case 'work_orders_index':
-        await refreshWorkOrders(pool, 'index');
+        result = await refreshWorkOrders(pool, 'index');
         break;
       case 'work_orders_pm':
-        await refreshWorkOrders(pool, 'pm');
+        result = await refreshWorkOrders(pool, 'pm');
         break;
       case 'work_orders_status':
-        await refreshWorkOrders(pool, 'prodstatus');
+        result = await refreshWorkOrders(pool, 'prodstatus');
         break;
       default:
         return res.status(400).json({ error: 'unknown job' });
     }
     await pool.request().input('n', sql.NVarChar, job)
       .query(`UPDATE dbo.UpdateSchedules SET LastRun = SYSUTCDATETIME() WHERE Name = @n`);
-    res.json({ ok: true });
+    res.json({ ok: true, result });
   } catch (e) {
     res.status(500).json({ error: String(e) });
   }


### PR DESCRIPTION
## Summary
- load mappings from multiple locations and normalize various shapes
- return inserted counts from KPI and work order refresh jobs
- bubble job results through admin API and UI for Run Now feedback

## Testing
- `npm test` *(fails: Property `fetchAndCache` does not exist; config.server required)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5292f4654832684082397da6899c8