### PR TITLE
Add full refresh pipeline and admin wiring

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -304,8 +304,10 @@
         <button id="run-wo-pm">Run WO: PM</button>
         <button id="run-wo-status">Run WO: Prod Status</button>
         <button id="run-all">Refresh All</button>
+        <button id="btn-full-refresh">Full Refresh (Limble → SQL → UI)</button>
       </div>
       <div id="run-status" style="margin-top:.5rem;color:#555;"></div>
+      <pre id="admin-log" style="height:200px;overflow:auto;background:#111;color:#0f0;padding:8px;"></pre>
     </section>
     </div>
     <script>
@@ -481,12 +483,28 @@
   (document.getElementById('run-byasset')  || {}).onclick = ()=>runJob('by_asset_kpis');
   (document.getElementById('run-wo-index') || {}).onclick = ()=>runJob('work_orders_index');
   (document.getElementById('run-wo-pm')    || {}).onclick = ()=>runJob('work_orders_pm');
-  (document.getElementById('run-wo-status')|| {}).onclick = ()=>runJob('work_orders_status');
-  (document.getElementById('run-all')      || {}).onclick = async ()=>{
-    const res = await fetch('/api/admin/refresh-all', { method: 'POST' });
-    const el = document.getElementById('run-status');
-    if (el) el.textContent = res.ok ? 'Refreshed all' : 'Refresh all failed';
-  };
+(document.getElementById('run-wo-status')|| {}).onclick = ()=>runJob('work_orders_status');
+(document.getElementById('run-all')      || {}).onclick = async ()=>{
+  const res = await fetch('/api/admin/refresh-all', { method: 'POST' });
+  const el = document.getElementById('run-status');
+  if (el) el.textContent = res.ok ? 'Refreshed all' : 'Refresh all failed';
+};
+</script>
+<script>
+  const logEl = document.getElementById('admin-log');
+  const log = msg => { logEl.textContent += msg + '\n'; logEl.scrollTop = logEl.scrollHeight; };
+  document.getElementById('btn-full-refresh')?.addEventListener('click', async (event) => {
+    const btn = event.target; btn.disabled = true; log('Starting full refresh…');
+    try {
+      const res = await fetch('/api/admin/full-refresh', { method:'POST' });
+      const data = await res.json();
+      if (!data.ok) throw new Error(data.error || 'Error');
+      data.steps.forEach(s => log(`${s.step}: ${s.ms}ms`));
+      log('✅ Full refresh complete');
+    } catch (e) {
+      log('❌ ' + e.message);
+    } finally { btn.disabled = false; }
+  });
 </script>
 <script type="module" src="js/header-kpis.js" defer></script>
 <script type="module" src="/js/admin.js"></script>

--- a/server/jobs/limbleSync.js
+++ b/server/jobs/limbleSync.js
@@ -1,0 +1,8 @@
+/** 
+ * Pull fresh data from Limble API and write into SQL tables.
+ * Replace this stub with your real ETL logic or stored-proc call.
+ */
+export async function syncLimbleToSql(pool) {
+  // e.g. await pool.request().execute('dbo.SyncFromLimble');
+  return { ok: true, note: 'stubbed limble→SQL sync' };
+}

--- a/server/jobs/pipeline.js
+++ b/server/jobs/pipeline.js
@@ -1,0 +1,43 @@
+import sql from 'mssql';
+import { refreshHeaderKpis, refreshByAssetKpis, refreshWorkOrders } from './kpiJobs.js';
+import { syncLimbleToSql } from './limbleSync.js';
+
+let running = false;
+
+export async function runFullRefresh(pool) {
+  if (running) return { started: false, reason: 'already running' };
+  running = true;
+  const out = { steps: [] };
+  try {
+    // 1) Limble → SQL
+    const t0 = Date.now();
+    const syncRes = await syncLimbleToSql(pool);
+    out.steps.push({ step: 'limble-sync', ms: Date.now() - t0, result: syncRes });
+
+    // 2) Header KPIs
+    const t1 = Date.now();
+    const hdr = await refreshHeaderKpis(pool);
+    out.steps.push({ step: 'header-kpis', ms: Date.now() - t1, result: hdr });
+
+    // 3) By-Asset KPIs
+    const t2 = Date.now();
+    const byAsset = await refreshByAssetKpis(pool);
+    out.steps.push({ step: 'by-asset-kpis', ms: Date.now() - t2, result: byAsset });
+
+    // 4) WorkOrders for each page
+    const pages = ['index','pm','prodstatus'];
+    for (const p of pages) {
+      const t3 = Date.now();
+      const res = await refreshWorkOrders(pool, p);
+      out.steps.push({ step: `workorders:${p}`, ms: Date.now() - t3, result: res });
+    }
+
+    out.ok = true;
+  } catch (e) {
+    out.ok = false;
+    out.error = e.message;
+  } finally {
+    running = false;
+  }
+  return out;
+}

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import { refreshHeaderKpis, refreshByAssetKpis, refreshWorkOrders } from '../jobs/kpiJobs.js';
+import { runFullRefresh } from '../jobs/pipeline.js';
+
+export default function adminRoutes(poolPromise) {
+  const r = express.Router();
+
+  // Full pipeline: Limble→SQL→UI caches
+  r.post('/admin/full-refresh', async (req, res) => {
+    const pool = await poolPromise;
+    const result = await runFullRefresh(pool);
+    res.json(result);
+  });
+
+  // Existing cache-refresh only:
+  r.post('/cache/refresh', async (req, res) => {
+    const pool = await poolPromise;
+    const hdr = await refreshHeaderKpis(pool);
+    const byAsset = await refreshByAssetKpis(pool);
+    const pages = ['index', 'pm', 'prodstatus'];
+    const work = [];
+    for (const p of pages) {
+      work.push(await refreshWorkOrders(pool, p));
+    }
+    res.json({ ok: true, header: hdr, byAsset, work });
+  });
+
+  return r;
+}


### PR DESCRIPTION
## Summary
- Implement `runFullRefresh` pipeline orchestrating Limble sync and UI cache rebuilds
- Stub Limble→SQL sync job
- Expose `/api/admin/full-refresh` route and front-end button with live logging
- Mount new admin routes and utility stubs in server

## Testing
- `npm test` *(fails: Cannot read properties of null (reading 'request'))*


------
https://chatgpt.com/codex/tasks/task_e_68a605dd871c832683ce89def2433f6d