### PR TITLE
Make server proxy-aware (trust proxy + HSTS controls)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ Production reporting (`server/routes/production.js`):
   - Override with `EXPECTED_RUN_DAYS` (e.g., `Mon-Fri`, `Sun-Sat`) and `EXPECTED_HOURS_PER_DAY`.
 - KPI time ranges default to last calendar week/month but can be overridden with `KPI_WEEK_START`, `KPI_WEEK_END`, `KPI_MONTH_START`, `KPI_MONTH_END` (Unix timestamps).
 
+## Reverse proxy notes
+
+- Set `TRUST_PROXY` to your reverse proxy hop count (`1`) or proxy IP/CIDR so Express trusts forwarded headers correctly.
+- Terminate TLS at the reverse proxy.
+- Ensure the proxy forwards both `X-Forwarded-For` and `X-Forwarded-Proto` headers to the app.
+
 ## KPI calculation logic
 
 | KPI | Timeframe | Description |

--- a/server.js
+++ b/server.js
@@ -589,12 +589,12 @@ const isPlainObject = (val) =>
 // ─── express setup ────────────────────────────────────────────────────────
 const app = express();
 
-// (optional) if you prefer to explicitly clear any caches that *do* hit HTTPS:
-app.use((req, res, next) => {
-  // sends a “forget HSTS” if this ever goes over TLS later
-  res.setHeader('Strict-Transport-Security', 'max-age=0');
-  next();
-});
+const trustProxy = process.env.TRUST_PROXY?.trim();
+if (trustProxy === '1') {
+  app.set('trust proxy', 1);
+} else if (trustProxy) {
+  app.set('trust proxy', trustProxy);
+}
 
 app.use(cors({ origin: true }));
 app.use(express.json());
@@ -643,16 +643,14 @@ app.use((req, _res, next) => {
   next();
 });
 
-// If you’re behind a proxy (NGINX/Cloudflare):
-// app.set('trust proxy', 1);
 
 // 2) guards/rate limits BEFORE routers (protect the whole /api/admin surface)
 app.use('/api/admin', adminAuthLimiter, adminSlowdown, adminLimiter);
 
 // Put this BEFORE routers
 app.use(helmet({
-  // 1) no HSTS (we are serving over HTTP right now)
-  hsts: false,
+  // 1) no HSTS by default in HTTP mode; enable if TLS is terminated upstream
+  hsts: process.env.ENABLE_HSTS === '1',
 
   // 2) COOP can be dropped in HTTP mode to avoid “untrustworthy origin” noise
   crossOriginOpenerPolicy: false,
@@ -681,12 +679,6 @@ app.use(helmet({
   // 4) CORP in HTTP is fine as cross-origin; you already had cross-origin
   crossOriginResourcePolicy: { policy: 'cross-origin' },
 }));
-
-// Optional: explicitly clear any leftover HSTS
-app.use((req, res, next) => {
-  res.set('Strict-Transport-Security', 'max-age=0');
-  next();
-});
 
 // 3) API routers
 app.use('/api', productionRoutes(poolPromise));   // /api/production/...


### PR DESCRIPTION
### Motivation

- Prepare the app for reverse-proxy deployment so Express correctly respects forwarded headers and secure/proto detection.
- Avoid forcibly clearing HSTS headers from the app so upstream TLS termination can manage HSTS policy.
- Make HSTS opt-in so HTTP-only deployments remain safe while allowing HSTS when TLS is terminated at the proxy.

### Description

- Added `TRUST_PROXY` env handling in `server.js` where `TRUST_PROXY='1'` sets `app.set('trust proxy', 1)` and any non-empty string sets `app.set('trust proxy', TRUST_PROXY)`.
- Removed the middleware that unconditionally set `Strict-Transport-Security: max-age=0` so the server no longer clears HSTS headers.
- Updated Helmet configuration to use `hsts: process.env.ENABLE_HSTS === '1'` so HSTS is disabled by default and can be enabled with `ENABLE_HSTS=1`.
- Added a short README section `Reverse proxy notes` describing `TRUST_PROXY`, TLS termination at the proxy, and forwarding `X-Forwarded-For`/`X-Forwarded-Proto`.

### Testing

- Ran `npm run -s lint` which completed successfully.
- Ran `npm test` which reported failures; the failing tests are due to pre-existing test/environment issues (scheduler DB dependency and test-suite expectations) and are not caused by the proxy/HSTS changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7313f6f0c832685a9a543fb7e7136)